### PR TITLE
Verify credentials according to spec

### DIFF
--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -132,7 +132,11 @@ function verifyCredentials({
   // verify the owner signature
   if (owner !== undefined) {
     let hashes = credHashes.map((c) => c.hash);
-    ownerSignature.verify(owner, [context, ...zip(hashes, issuers).flat()]);
+    let ok = ownerSignature.verify(owner, [
+      context,
+      ...zip(hashes, issuers).flat(),
+    ]);
+    ok.assertTrue('Invalid owner signature');
   }
 
   return {

--- a/src/deserialize-spec.ts
+++ b/src/deserialize-spec.ts
@@ -67,8 +67,6 @@ function deserializeInput(input: any): Input {
       );
     case 'public':
       return Input.claim(deserializeNestedProvablePure(input.data));
-    case 'private':
-      return Input.private(deserializeNestedProvable(input.data));
     case 'credential': {
       let id: CredentialId = input.id;
       let data = deserializeNestedProvablePure(input.data);

--- a/src/program-spec.ts
+++ b/src/program-spec.ts
@@ -403,23 +403,24 @@ function dataInputTypes<S extends Spec>({ inputs }: S): NestedProvable {
 
 function splitUserInputs<S extends Spec>(
   spec: S,
-  userInputs: Record<string, any>
+  userInputs: UserInputs<any>
 ): {
   publicInput: PublicInputs<S['inputs']>;
   privateInput: PrivateInputs<S['inputs']>;
 };
 function splitUserInputs<S extends Spec>(
   spec: S,
-  userInputs: Record<string, any>
+  { context, ownerSignature, inputs: userInputs }: UserInputs<any>
 ) {
   let claims: Record<string, any> = {};
   let privateCredentialInputs: Record<string, any> = {};
 
   Object.entries(spec.inputs).forEach(([key, input]) => {
+    let userInput: any = userInputs[key];
     if (input.type === 'credential') {
       privateCredentialInputs[key] = {
-        credential: userInputs[key].credential,
-        private: userInputs[key].private,
+        credential: userInput.credential,
+        private: userInput.private,
       };
     }
     if (input.type === 'claim') {
@@ -432,12 +433,6 @@ function splitUserInputs<S extends Spec>(
       // do nothing
     }
   });
-
-  // TODO take context from user inputs
-  let context = Field(0);
-
-  // TODO take ownerSignature from user inputs
-  let ownerSignature = Signature.empty();
 
   return {
     publicInput: { context, claims },
@@ -505,10 +500,11 @@ type PrivateInputs<Inputs extends Record<string, Input>> = {
   privateCredentialInputs: ExcludeFromRecord<MapToPrivate<Inputs>, never>;
 };
 
-type UserInputs<Inputs extends Record<string, Input>> = ExcludeFromRecord<
-  MapToUserInput<Inputs>,
-  never
->;
+type UserInputs<Inputs extends Record<string, Input>> = {
+  context: Field;
+  ownerSignature: Signature;
+  inputs: ExcludeFromRecord<MapToUserInput<Inputs>, never>;
+};
 
 type DataInputs<Inputs extends Record<string, Input>> = ExcludeFromRecord<
   MapToDataInput<Inputs>,

--- a/src/program.ts
+++ b/src/program.ts
@@ -78,7 +78,7 @@ function createProgram<S extends Spec>(
       return result.verificationKey;
     },
     async run(input) {
-      let { publicInput, privateInput } = splitUserInputs(spec, input);
+      let { publicInput, privateInput } = splitUserInputs(input);
       let result = await program.run(publicInput, privateInput);
       return result as any;
     },

--- a/src/program.ts
+++ b/src/program.ts
@@ -1,4 +1,4 @@
-import { Proof, VerificationKey, ZkProgram } from 'o1js';
+import { Field, Proof, Signature, VerificationKey, ZkProgram } from 'o1js';
 import {
   Input,
   Node,
@@ -47,7 +47,13 @@ function createProgram<S extends Spec>(
     methods: {
       run: {
         privateInputs: [PrivateInput],
-        method(publicInput, privateInput) {
+        method(
+          publicInput: { context: Field; claims: Record<string, any> },
+          privateInput: {
+            ownerSignature: Signature;
+            privateCredentialInputs: Record<string, any>;
+          }
+        ) {
           let credentials = extractCredentialInputs(
             spec,
             publicInput,

--- a/src/program.ts
+++ b/src/program.ts
@@ -8,12 +8,13 @@ import {
   recombineDataInputs,
   Spec,
   splitUserInputs,
-  verifyCredentials,
+  extractCredentialInputs,
   type PublicInputs,
   type UserInputs,
 } from './program-spec.ts';
 import { NestedProvable } from './nested.ts';
 import { type ProvablePureType } from './o1js-missing.ts';
+import { verifyCredentials } from './credentials.ts';
 
 export { createProgram };
 
@@ -47,7 +48,13 @@ function createProgram<S extends Spec>(
       run: {
         privateInputs: [PrivateInput],
         method(publicInput, privateInput) {
-          verifyCredentials(spec, publicInput, privateInput);
+          let credentials = extractCredentialInputs(
+            spec,
+            publicInput,
+            privateInput
+          );
+          // TODO return issuers from this function and pass it to app logic
+          verifyCredentials(credentials);
 
           let root = recombineDataInputs(spec, publicInput, privateInput);
           let assertion = Node.eval(root, spec.logic.assert);

--- a/src/serialize-spec.ts
+++ b/src/serialize-spec.ts
@@ -10,6 +10,7 @@ import {
   PublicKey,
   Signature,
   Provable,
+  Undefined,
 } from 'o1js';
 
 // Supported o1js base types
@@ -21,6 +22,7 @@ const O1jsType = {
   UInt64: 'UInt64',
   PublicKey: 'PublicKey',
   Signature: 'Signature',
+  Undefined: 'Undefined',
 } as const;
 
 type O1jsTypeName = (typeof O1jsType)[keyof typeof O1jsType];
@@ -33,6 +35,7 @@ const supportedTypes: Record<O1jsTypeName, Provable<any>> = {
   [O1jsType.UInt64]: UInt64,
   [O1jsType.PublicKey]: PublicKey,
   [O1jsType.Signature]: Signature,
+  [O1jsType.Undefined]: Undefined,
 };
 
 let mapProvableTypeToName = new Map<ProvableType<any>, string>();
@@ -104,12 +107,6 @@ function serializeInput(input: Input): any {
       case 'claim': {
         return {
           type: 'public',
-          data: serializeNestedProvable(input.data),
-        };
-      }
-      case 'private': {
-        return {
-          type: 'private',
           data: serializeNestedProvable(input.data),
         };
       }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-export { assert, assertHasProperty, hasProperty, assertIsObject };
+export { assert, assertHasProperty, hasProperty, assertIsObject, zip };
 
 function assert(condition: boolean, message?: string): asserts condition {
   if (!condition) {
@@ -33,4 +33,9 @@ function hasProperty<K extends string>(
     ((typeof obj === 'object' && obj !== null) || typeof obj === 'function') &&
     key in obj
   );
+}
+
+function zip<T, S>(a: T[], b: S[]) {
+  assert(a.length === b.length, 'zip(): arrays of unequal length');
+  return a.map((a, i): [T, S] => [a, b[i]!]);
 }

--- a/tests/deserialize.test.ts
+++ b/tests/deserialize.test.ts
@@ -200,7 +200,7 @@ test('deserializeInput', async (t) => {
   });
 
   await t.test('should deserialize private input', () => {
-    const input = Input.private(Signature);
+    const input = Credential.none(Signature);
     const serialized = serializeInput(input);
     const deserialized = deserializeInput(serialized);
 
@@ -229,7 +229,7 @@ test('deserializeInput', async (t) => {
   });
 
   await t.test('should deserialize nested input', () => {
-    const input = Input.private({
+    const input = Credential.none({
       personal: {
         age: Field,
         id: UInt64,
@@ -258,10 +258,10 @@ test('deserializeInput', async (t) => {
 test('deserializeInputs', async (t) => {
   await t.test('should deserialize inputs with various type', () => {
     const inputs = {
-      field: Input.private(Field),
+      field: Credential.none(Field),
       bool: Input.claim(Bool),
       uint: Input.constant(UInt64, UInt64.from(42)),
-      nested: Input.private({
+      nested: Credential.none({
         inner: Field,
         deep: {
           value: Bool,
@@ -302,7 +302,7 @@ test('deserializeInputs', async (t) => {
 
   await t.test('should handle mixed input types', () => {
     const inputs = {
-      privateField: Input.private(Field),
+      privateField: Credential.none(Field),
       publicBool: Input.claim(Bool),
       constantUint: Input.constant(UInt32, UInt32.from(42)),
       credential: Credential.signatureNative({ score: UInt64 }),
@@ -341,7 +341,7 @@ test('deserializeNode', async (t) => {
 
   await t.test('should deserialize root node', () => {
     let input = {
-      age: Input.private(Field),
+      age: Credential.none(Field),
       isAdmin: Input.claim(Bool),
     };
     const node: Node = { type: 'root', input };
@@ -352,7 +352,7 @@ test('deserializeNode', async (t) => {
 
   await t.test('should deserialize property node', () => {
     let input = {
-      age: Input.private(Field),
+      age: Credential.none(Field),
       isAdmin: Input.claim(Bool),
     };
     const node: Node = {
@@ -442,7 +442,7 @@ test('deserializeSpec', async (t) => {
   await t.test('should correctly deserialize a simple Spec', async () => {
     const originalSpec = Spec(
       {
-        age: Input.private(Field),
+        age: Credential.none(Field),
         isAdmin: Input.claim(Bool),
         maxAge: Input.constant(Field, Field(100)),
       },
@@ -510,8 +510,8 @@ test('deserializeSpec', async (t) => {
     async () => {
       const originalSpec = Spec(
         {
-          field1: Input.private(Field),
-          field2: Input.private(Field),
+          field1: Credential.none(Field),
+          field2: Credential.none(Field),
           threshold: Input.claim(UInt64),
         },
         ({ field1, field2, threshold }) => ({

--- a/tests/program-spec.test.ts
+++ b/tests/program-spec.test.ts
@@ -215,9 +215,15 @@ test(' Spec and Node operations', async (t) => {
     const signedData = createSignatureCredential(InputData, data);
 
     let userInputs: UserInputs<typeof spec.inputs> = {
-      signedData,
-      targetAge: Field(30),
-      targetName: Bytes32.fromString('David'),
+      context: Field(0),
+      // TODO actual owner signature
+      ownerSignature: signedData.private.issuerSignature,
+
+      inputs: {
+        signedData,
+        targetAge: Field(30),
+        targetName: Bytes32.fromString('David'),
+      },
     };
 
     let { privateInput, publicInput } = splitUserInputs(spec, userInputs);

--- a/tests/program-spec.test.ts
+++ b/tests/program-spec.test.ts
@@ -9,6 +9,7 @@ import {
   type UserInputs,
   splitUserInputs,
   recombineDataInputs,
+  type DataInputs,
 } from '../src/program-spec.ts';
 import { createSignatureCredential, owner } from './test-utils.ts';
 import { Credential } from '../src/credentials.ts';
@@ -20,7 +21,7 @@ test(' Spec and Node operations', async (t) => {
     const InputData = { age: Field };
     const spec = Spec(
       {
-        data: Input.private(InputData),
+        data: Credential.none(InputData),
         targetAge: Input.claim(Field),
       },
       ({ data, targetAge }) => ({
@@ -29,8 +30,8 @@ test(' Spec and Node operations', async (t) => {
       })
     );
 
-    const root = {
-      data: { age: Field(25) },
+    const root: DataInputs<typeof spec.inputs> = {
+      data: { owner, data: { age: Field(25) } },
       targetAge: Field(25),
     };
 
@@ -45,7 +46,7 @@ test(' Spec and Node operations', async (t) => {
     const InputData = { age: Field, name: Bytes32 };
     const spec = Spec(
       {
-        data: Input.private(InputData),
+        data: Credential.none(InputData),
         targetAge: Input.claim(Field),
         targetName: Input.claim(Bytes32),
       },
@@ -58,8 +59,11 @@ test(' Spec and Node operations', async (t) => {
       })
     );
 
-    const root = {
-      data: { age: Field(30), name: Bytes32.fromString('Alice') },
+    const root: DataInputs<typeof spec.inputs> = {
+      data: {
+        owner,
+        data: { age: Field(30), name: Bytes32.fromString('Alice') },
+      },
       targetAge: Field(30),
       targetName: Bytes32.fromString('Alice'),
     };
@@ -75,7 +79,7 @@ test(' Spec and Node operations', async (t) => {
     const InputData = { age: Field, name: Bytes32 };
     const spec = Spec(
       {
-        data: Input.private(InputData),
+        data: Credential.none(InputData),
         targetAge: Input.claim(Field),
         targetName: Input.claim(Bytes32),
       },
@@ -88,8 +92,11 @@ test(' Spec and Node operations', async (t) => {
       })
     );
 
-    const root = {
-      data: { age: Field(30), name: Bytes32.fromString('Alice') },
+    const root: DataInputs<typeof spec.inputs> = {
+      data: {
+        owner,
+        data: { age: Field(30), name: Bytes32.fromString('Alice') },
+      },
       targetAge: Field(18),
       targetName: Bytes32.fromString('Alice'),
     };
@@ -105,7 +112,7 @@ test(' Spec and Node operations', async (t) => {
     const InputData = { age: Field, name: Bytes32 };
     const spec = Spec(
       {
-        data: Input.private(InputData),
+        data: Credential.none(InputData),
         targetAge: Input.claim(Field),
         targetName: Input.claim(Bytes32),
       },
@@ -118,8 +125,11 @@ test(' Spec and Node operations', async (t) => {
       })
     );
 
-    const root = {
-      data: { age: Field(30), name: Bytes32.fromString('Alice') },
+    const root: DataInputs<typeof spec.inputs> = {
+      data: {
+        owner,
+        data: { age: Field(30), name: Bytes32.fromString('Alice') },
+      },
       targetAge: Field(30),
       targetName: Bytes32.fromString('Alice'),
     };
@@ -137,7 +147,7 @@ test(' Spec and Node operations', async (t) => {
 
     const spec = Spec(
       {
-        data: Input.private(NestedInputData),
+        data: Credential.none(NestedInputData),
         targetAge: Input.claim(Field),
         targetPoints: Input.claim(Field),
       },
@@ -153,10 +163,13 @@ test(' Spec and Node operations', async (t) => {
       })
     );
 
-    const root = {
+    const root: DataInputs<typeof spec.inputs> = {
       data: {
-        person: { age: Field(25), name: Bytes32.fromString('Bob') },
-        points: Field(100),
+        owner,
+        data: {
+          person: { age: Field(25), name: Bytes32.fromString('Bob') },
+          points: Field(100),
+        },
       },
       targetAge: Field(25),
       targetPoints: Field(100),
@@ -173,7 +186,7 @@ test(' Spec and Node operations', async (t) => {
     const InputData = { age: Field, name: Bytes32 };
     const spec = Spec(
       {
-        data: Input.private(InputData),
+        data: Credential.none(InputData),
         constAge: Input.constant(Field, Field(25)),
       },
       ({ data, constAge }) => ({
@@ -182,8 +195,11 @@ test(' Spec and Node operations', async (t) => {
       })
     );
 
-    const root = {
-      data: { age: Field(25), name: Bytes32.fromString('Charlie') },
+    const root: DataInputs<typeof spec.inputs> = {
+      data: {
+        owner,
+        data: { age: Field(25), name: Bytes32.fromString('Charlie') },
+      },
       constAge: Field(25),
     };
 

--- a/tests/program-spec.test.ts
+++ b/tests/program-spec.test.ts
@@ -218,15 +218,11 @@ test(' Spec and Node operations', async (t) => {
       context: Field(0),
       // TODO actual owner signature
       ownerSignature: signedData.private.issuerSignature,
-
-      inputs: {
-        signedData,
-        targetAge: Field(30),
-        targetName: Bytes32.fromString('David'),
-      },
+      credentials: { signedData },
+      claims: { targetAge: Field(30), targetName: Bytes32.fromString('David') },
     };
 
-    let { privateInput, publicInput } = splitUserInputs(spec, userInputs);
+    let { privateInput, publicInput } = splitUserInputs(userInputs);
     let root = recombineDataInputs(spec, publicInput, privateInput);
 
     assert.deepStrictEqual(root, {

--- a/tests/program-spec.test.ts
+++ b/tests/program-spec.test.ts
@@ -14,6 +14,10 @@ import {
 import { createSignatureCredential, owner } from './test-utils.ts';
 import { Credential } from '../src/credentials.ts';
 
+function cred<D>(data: D): Credential<D> {
+  return { owner, data };
+}
+
 test(' Spec and Node operations', async (t) => {
   const Bytes32 = Bytes(32);
 
@@ -31,7 +35,7 @@ test(' Spec and Node operations', async (t) => {
     );
 
     const root: DataInputs<typeof spec.inputs> = {
-      data: { owner, data: { age: Field(25) } },
+      data: cred({ age: Field(25) }),
       targetAge: Field(25),
     };
 
@@ -42,10 +46,10 @@ test(' Spec and Node operations', async (t) => {
     assert.deepStrictEqual(dataResult, Field(25));
   });
 
-  const data: Credential<{ age: Field; name: Bytes }> = {
-    owner,
-    data: { age: Field(30), name: Bytes32.fromString('Alice') },
-  };
+  const data: Credential<{ age: Field; name: Bytes }> = cred({
+    age: Field(30),
+    name: Bytes32.fromString('Alice'),
+  });
 
   await t.test('Spec with multiple assertions - and', () => {
     const InputData = { age: Field, name: Bytes32 };
@@ -155,12 +159,8 @@ test(' Spec and Node operations', async (t) => {
           data: Operation.property(data, 'age'),
         })
       );
-
       const root: DataInputs<typeof spec.inputs> = {
-        data: {
-          owner,
-          data: { age: Field(11), name: Bytes32.fromString('Alice') },
-        },
+        data: cred({ age: Field(11), name: Bytes32.fromString('Alice') }),
         targetAge: Field(30),
         targetName: Bytes32.fromString('Alice'),
       };
@@ -193,10 +193,7 @@ test(' Spec and Node operations', async (t) => {
     );
 
     const root: DataInputs<typeof spec.inputs> = {
-      data: {
-        owner,
-        data: { age: Field(11), name: Bytes32.fromString('Alice') },
-      },
+      data: cred({ age: Field(11), name: Bytes32.fromString('Alice') }),
       targetAge: Field(30),
       targetName: Bytes32.fromString('Alice'),
     };
@@ -228,7 +225,7 @@ test(' Spec and Node operations', async (t) => {
     const expectedHashValue = Poseidon.hash([inputValue]);
 
     const root: DataInputs<typeof spec.inputs> = {
-      data: { owner, data: { value: inputValue } },
+      data: cred({ value: inputValue }),
       expectedHash: expectedHashValue,
     };
 
@@ -257,10 +254,7 @@ test(' Spec and Node operations', async (t) => {
     );
 
     const root: DataInputs<typeof spec.inputs> = {
-      data: {
-        owner,
-        data: { age: Field(30), name: Bytes32.fromString('Alice') },
-      },
+      data: cred({ age: Field(30), name: Bytes32.fromString('Alice') }),
       targetAge: Field(18),
       targetName: Bytes32.fromString('Alice'),
     };
@@ -290,10 +284,7 @@ test(' Spec and Node operations', async (t) => {
     );
 
     const root: DataInputs<typeof spec.inputs> = {
-      data: {
-        owner,
-        data: { age: Field(30), name: Bytes32.fromString('Alice') },
-      },
+      data: cred({ age: Field(30), name: Bytes32.fromString('Alice') }),
       targetAge: Field(30),
       targetName: Bytes32.fromString('Alice'),
     };
@@ -319,8 +310,8 @@ test(' Spec and Node operations', async (t) => {
     );
 
     const root: DataInputs<typeof spec.inputs> = {
-      value1: { owner, data: UInt32.from(1000000) },
-      value2: { owner, data: UInt64.from(1000000) },
+      value1: cred(UInt32.from(1000000)),
+      value2: cred(UInt64.from(1000000)),
       sum: UInt64.from(2000000),
     };
 
@@ -345,8 +336,8 @@ test(' Spec and Node operations', async (t) => {
     );
 
     const root: DataInputs<typeof spec.inputs> = {
-      value1: { owner, data: UInt32.from(1000) },
-      value2: { owner, data: UInt8.from(200) },
+      value1: cred(UInt32.from(1000)),
+      value2: cred(UInt8.from(200)),
       difference: UInt32.from(800),
     };
 
@@ -371,8 +362,8 @@ test(' Spec and Node operations', async (t) => {
     );
 
     const root: DataInputs<typeof spec.inputs> = {
-      value1: { owner, data: UInt32.from(1000) },
-      value2: { owner, data: UInt64.from(2000) },
+      value1: cred(UInt32.from(1000)),
+      value2: cred(UInt64.from(2000)),
       product: UInt64.from(2000000),
     };
 
@@ -397,8 +388,8 @@ test(' Spec and Node operations', async (t) => {
     );
 
     const root: DataInputs<typeof spec.inputs> = {
-      value1: { owner, data: UInt64.from(1000000) },
-      value2: { owner, data: UInt32.from(1000) },
+      value1: cred(UInt64.from(1000000)),
+      value2: cred(UInt32.from(1000)),
       quotient: UInt64.from(1000),
     };
 
@@ -429,7 +420,7 @@ test(' Spec and Node operations', async (t) => {
 
     // value < threshold
     const root1 = {
-      data: { owner, data: { value: Field(5) } },
+      data: cred({ value: Field(5) }),
       threshold: Field(10),
       zero: Field(0),
     };
@@ -439,7 +430,7 @@ test(' Spec and Node operations', async (t) => {
 
     // value >= threshold
     const root2 = {
-      data: { owner, data: { value: Field(15) } },
+      data: cred({ value: Field(15) }),
       threshold: Field(10),
       zero: Field(0),
     };
@@ -471,7 +462,7 @@ test(' Spec and Node operations', async (t) => {
 
     // value < threshold and < lowLimit (should pass)
     const root1 = {
-      data: { owner, data: { value: Field(5) } },
+      data: cred({ value: Field(5) }),
       threshold: Field(15),
       lowLimit: Field(10),
       highLimit: Field(20),
@@ -482,7 +473,7 @@ test(' Spec and Node operations', async (t) => {
 
     // value >= threshold and >= highLimit (should pass)
     const root2 = {
-      data: { owner, data: { value: Field(25) } },
+      data: cred({ value: Field(25) }),
       threshold: Field(15),
       lowLimit: Field(10),
       highLimit: Field(20),
@@ -493,7 +484,7 @@ test(' Spec and Node operations', async (t) => {
 
     // lowLimit <= value < threshold (should fail)
     const root3 = {
-      data: { owner, data: { value: Field(12) } },
+      data: cred({ value: Field(12) }),
       threshold: Field(15),
       lowLimit: Field(10),
       highLimit: Field(20),
@@ -504,7 +495,7 @@ test(' Spec and Node operations', async (t) => {
 
     // threshold <= value < highLimit (should fail)
     const root4 = {
-      data: { owner, data: { value: Field(18) } },
+      data: cred({ value: Field(18) }),
       threshold: Field(15),
       lowLimit: Field(10),
       highLimit: Field(20),
@@ -538,7 +529,7 @@ test(' Spec and Node operations', async (t) => {
 
     // 10 < value < threshold < highLimit (should pass)
     const root1 = {
-      data: { owner, data: { value: Field(15) } },
+      data: cred({ value: Field(15) }),
       threshold: Field(18),
       lowLimit: Field(10),
       highLimit: Field(20),
@@ -549,7 +540,7 @@ test(' Spec and Node operations', async (t) => {
 
     // 10 < threshold <= value = highLimit (should pass)
     const root2 = {
-      data: { owner, data: { value: Field(20) } },
+      data: cred({ value: Field(20) }),
       threshold: Field(18),
       lowLimit: Field(10),
       highLimit: Field(20),
@@ -560,7 +551,7 @@ test(' Spec and Node operations', async (t) => {
 
     // value <= lowLimit (should fail)
     const root3 = {
-      data: { owner, data: { value: Field(10) } },
+      data: cred({ value: Field(10) }),
       threshold: Field(18),
       lowLimit: Field(10),
       highLimit: Field(20),
@@ -571,7 +562,7 @@ test(' Spec and Node operations', async (t) => {
 
     // 10 < threshold <= value < highLimit (should fail)
     const root4 = {
-      data: { owner, data: { value: Field(19) } },
+      data: cred({ value: Field(19) }),
       threshold: Field(18),
       lowLimit: Field(10),
       highLimit: Field(20),
@@ -604,13 +595,10 @@ test(' Spec and Node operations', async (t) => {
     );
 
     const root: DataInputs<typeof spec.inputs> = {
-      data: {
-        owner,
-        data: {
-          person: { age: Field(25), name: Bytes32.fromString('Bob') },
-          points: Field(100),
-        },
-      },
+      data: cred({
+        person: { age: Field(25), name: Bytes32.fromString('Bob') },
+        points: Field(100),
+      }),
       targetAge: Field(25),
       targetPoints: Field(100),
     };
@@ -636,10 +624,7 @@ test(' Spec and Node operations', async (t) => {
     );
 
     const root: DataInputs<typeof spec.inputs> = {
-      data: {
-        owner,
-        data: { age: Field(25), name: Bytes32.fromString('Charlie') },
-      },
+      data: cred({ age: Field(25), name: Bytes32.fromString('Charlie') }),
       constAge: Field(25),
     };
 
@@ -682,7 +667,7 @@ test(' Spec and Node operations', async (t) => {
     let root = recombineDataInputs(spec, publicInput, privateInput);
 
     assert.deepStrictEqual(root, {
-      signedData: { owner, data },
+      signedData: cred(data),
       targetAge: Field(30),
       targetName: Bytes32.fromString('David'),
     });

--- a/tests/program-spec.test.ts
+++ b/tests/program-spec.test.ts
@@ -42,6 +42,11 @@ test(' Spec and Node operations', async (t) => {
     assert.deepStrictEqual(dataResult, Field(25));
   });
 
+  const data: Credential<{ age: Field; name: Bytes }> = {
+    owner,
+    data: { age: Field(30), name: Bytes32.fromString('Alice') },
+  };
+
   await t.test('Spec with multiple assertions - and', () => {
     const InputData = { age: Field, name: Bytes32 };
     const spec = Spec(
@@ -60,10 +65,7 @@ test(' Spec and Node operations', async (t) => {
     );
 
     const root: DataInputs<typeof spec.inputs> = {
-      data: {
-        owner,
-        data: { age: Field(30), name: Bytes32.fromString('Alice') },
-      },
+      data,
       targetAge: Field(30),
       targetName: Bytes32.fromString('Alice'),
     };
@@ -79,7 +81,7 @@ test(' Spec and Node operations', async (t) => {
     const InputData = { age: Field, name: Bytes32 };
     const spec = Spec(
       {
-        data: Input.private(InputData),
+        data: Credential.none(InputData),
         targetAge: Input.claim(Field),
         targetName: Input.claim(Bytes32),
       },
@@ -92,8 +94,8 @@ test(' Spec and Node operations', async (t) => {
       })
     );
 
-    const root = {
-      data: { age: Field(30), name: Bytes32.fromString('Alice') },
+    const root: DataInputs<typeof spec.inputs> = {
+      data,
       targetAge: Field(30),
       targetName: Bytes32.fromString('Alice'),
     };
@@ -109,7 +111,7 @@ test(' Spec and Node operations', async (t) => {
     const InputData = { age: Field, name: Bytes32 };
     const spec = Spec(
       {
-        data: Input.private(InputData),
+        data: Credential.none(InputData),
         targetAge: Input.claim(Field),
         targetName: Input.claim(Bytes32),
       },
@@ -122,8 +124,8 @@ test(' Spec and Node operations', async (t) => {
       })
     );
 
-    const root = {
-      data: { age: Field(30), name: Bytes32.fromString('Alice') },
+    const root: DataInputs<typeof spec.inputs> = {
+      data,
       targetAge: Field(30),
       targetName: Bytes32.fromString('Bob'),
     };
@@ -141,7 +143,7 @@ test(' Spec and Node operations', async (t) => {
       const InputData = { age: Field, name: Bytes32 };
       const spec = Spec(
         {
-          data: Input.private(InputData),
+          data: Credential.none(InputData),
           targetAge: Input.claim(Field),
           targetName: Input.claim(Bytes32),
         },
@@ -154,8 +156,11 @@ test(' Spec and Node operations', async (t) => {
         })
       );
 
-      const root = {
-        data: { age: Field(11), name: Bytes32.fromString('Alice') },
+      const root: DataInputs<typeof spec.inputs> = {
+        data: {
+          owner,
+          data: { age: Field(11), name: Bytes32.fromString('Alice') },
+        },
         targetAge: Field(30),
         targetName: Bytes32.fromString('Alice'),
       };
@@ -172,7 +177,7 @@ test(' Spec and Node operations', async (t) => {
     const InputData = { age: Field, name: Bytes32 };
     const spec = Spec(
       {
-        data: Input.private(InputData),
+        data: Credential.none(InputData),
         targetAge: Input.claim(Field),
         targetName: Input.claim(Bytes32),
       },
@@ -187,8 +192,11 @@ test(' Spec and Node operations', async (t) => {
       })
     );
 
-    const root = {
-      data: { age: Field(11), name: Bytes32.fromString('Alice') },
+    const root: DataInputs<typeof spec.inputs> = {
+      data: {
+        owner,
+        data: { age: Field(11), name: Bytes32.fromString('Alice') },
+      },
       targetAge: Field(30),
       targetName: Bytes32.fromString('Alice'),
     };
@@ -204,7 +212,7 @@ test(' Spec and Node operations', async (t) => {
     const InputData = { value: Field };
     const spec = Spec(
       {
-        data: Input.private(InputData),
+        data: Credential.none(InputData),
         expectedHash: Input.claim(Field),
       },
       ({ data, expectedHash }) => ({
@@ -219,8 +227,8 @@ test(' Spec and Node operations', async (t) => {
     const inputValue = Field(123456);
     const expectedHashValue = Poseidon.hash([inputValue]);
 
-    const root = {
-      data: { value: inputValue },
+    const root: DataInputs<typeof spec.inputs> = {
+      data: { owner, data: { value: inputValue } },
       expectedHash: expectedHashValue,
     };
 
@@ -300,8 +308,8 @@ test(' Spec and Node operations', async (t) => {
   await t.test('Spec with add UInt32 and UInt64', () => {
     const spec = Spec(
       {
-        value1: Input.private(UInt32),
-        value2: Input.private(UInt64),
+        value1: Credential.none(UInt32),
+        value2: Credential.none(UInt64),
         sum: Input.claim(UInt64),
       },
       ({ value1, value2, sum }) => ({
@@ -310,9 +318,9 @@ test(' Spec and Node operations', async (t) => {
       })
     );
 
-    const root = {
-      value1: UInt32.from(1000000),
-      value2: UInt64.from(1000000),
+    const root: DataInputs<typeof spec.inputs> = {
+      value1: { owner, data: UInt32.from(1000000) },
+      value2: { owner, data: UInt64.from(1000000) },
       sum: UInt64.from(2000000),
     };
 
@@ -326,8 +334,8 @@ test(' Spec and Node operations', async (t) => {
   await t.test('Spec with sub UInt32 and UInt8', () => {
     const spec = Spec(
       {
-        value1: Input.private(UInt32),
-        value2: Input.private(UInt8),
+        value1: Credential.none(UInt32),
+        value2: Credential.none(UInt8),
         difference: Input.claim(UInt32),
       },
       ({ value1, value2, difference }) => ({
@@ -336,9 +344,9 @@ test(' Spec and Node operations', async (t) => {
       })
     );
 
-    const root = {
-      value1: UInt32.from(1000),
-      value2: UInt8.from(200),
+    const root: DataInputs<typeof spec.inputs> = {
+      value1: { owner, data: UInt32.from(1000) },
+      value2: { owner, data: UInt8.from(200) },
       difference: UInt32.from(800),
     };
 
@@ -352,8 +360,8 @@ test(' Spec and Node operations', async (t) => {
   await t.test('Spec with mul UInt32 and UInt64', () => {
     const spec = Spec(
       {
-        value1: Input.private(UInt32),
-        value2: Input.private(UInt64),
+        value1: Credential.none(UInt32),
+        value2: Credential.none(UInt64),
         product: Input.claim(UInt64),
       },
       ({ value1, value2, product }) => ({
@@ -362,9 +370,9 @@ test(' Spec and Node operations', async (t) => {
       })
     );
 
-    const root = {
-      value1: UInt32.from(1000),
-      value2: UInt64.from(2000),
+    const root: DataInputs<typeof spec.inputs> = {
+      value1: { owner, data: UInt32.from(1000) },
+      value2: { owner, data: UInt64.from(2000) },
       product: UInt64.from(2000000),
     };
 
@@ -378,8 +386,8 @@ test(' Spec and Node operations', async (t) => {
   await t.test('Spec with div UInt64 and UInt32', () => {
     const spec = Spec(
       {
-        value1: Input.private(UInt64),
-        value2: Input.private(UInt32),
+        value1: Credential.none(UInt64),
+        value2: Credential.none(UInt32),
         quotient: Input.claim(UInt64),
       },
       ({ value1, value2, quotient }) => ({
@@ -388,9 +396,9 @@ test(' Spec and Node operations', async (t) => {
       })
     );
 
-    const root = {
-      value1: UInt64.from(1000000),
-      value2: UInt32.from(1000),
+    const root: DataInputs<typeof spec.inputs> = {
+      value1: { owner, data: UInt64.from(1000000) },
+      value2: { owner, data: UInt32.from(1000) },
       quotient: UInt64.from(1000),
     };
 
@@ -405,7 +413,7 @@ test(' Spec and Node operations', async (t) => {
     const InputData = { value: Field };
     const spec = Spec(
       {
-        data: Input.private(InputData),
+        data: Credential.none(InputData),
         threshold: Input.claim(Field),
         zero: Input.constant(Field, Field(0)),
       },
@@ -421,7 +429,7 @@ test(' Spec and Node operations', async (t) => {
 
     // value < threshold
     const root1 = {
-      data: { value: Field(5) },
+      data: { owner, data: { value: Field(5) } },
       threshold: Field(10),
       zero: Field(0),
     };
@@ -431,7 +439,7 @@ test(' Spec and Node operations', async (t) => {
 
     // value >= threshold
     const root2 = {
-      data: { value: Field(15) },
+      data: { owner, data: { value: Field(15) } },
       threshold: Field(10),
       zero: Field(0),
     };
@@ -444,7 +452,7 @@ test(' Spec and Node operations', async (t) => {
     const InputData = { value: Field };
     const spec = Spec(
       {
-        data: Input.private(InputData),
+        data: Credential.none(InputData),
         threshold: Input.claim(Field),
         lowLimit: Input.constant(Field, Field(10)),
         highLimit: Input.constant(Field, Field(20)),
@@ -463,7 +471,7 @@ test(' Spec and Node operations', async (t) => {
 
     // value < threshold and < lowLimit (should pass)
     const root1 = {
-      data: { value: Field(5) },
+      data: { owner, data: { value: Field(5) } },
       threshold: Field(15),
       lowLimit: Field(10),
       highLimit: Field(20),
@@ -474,7 +482,7 @@ test(' Spec and Node operations', async (t) => {
 
     // value >= threshold and >= highLimit (should pass)
     const root2 = {
-      data: { value: Field(25) },
+      data: { owner, data: { value: Field(25) } },
       threshold: Field(15),
       lowLimit: Field(10),
       highLimit: Field(20),
@@ -485,7 +493,7 @@ test(' Spec and Node operations', async (t) => {
 
     // lowLimit <= value < threshold (should fail)
     const root3 = {
-      data: { value: Field(12) },
+      data: { owner, data: { value: Field(12) } },
       threshold: Field(15),
       lowLimit: Field(10),
       highLimit: Field(20),
@@ -496,7 +504,7 @@ test(' Spec and Node operations', async (t) => {
 
     // threshold <= value < highLimit (should fail)
     const root4 = {
-      data: { value: Field(18) },
+      data: { owner, data: { value: Field(18) } },
       threshold: Field(15),
       lowLimit: Field(10),
       highLimit: Field(20),
@@ -510,7 +518,7 @@ test(' Spec and Node operations', async (t) => {
     const InputData = { value: Field };
     const spec = Spec(
       {
-        data: Input.private(InputData),
+        data: Credential.none(InputData),
         threshold: Input.claim(Field),
         lowLimit: Input.constant(Field, Field(10)),
         highLimit: Input.constant(Field, Field(20)),
@@ -530,7 +538,7 @@ test(' Spec and Node operations', async (t) => {
 
     // 10 < value < threshold < highLimit (should pass)
     const root1 = {
-      data: { value: Field(15) },
+      data: { owner, data: { value: Field(15) } },
       threshold: Field(18),
       lowLimit: Field(10),
       highLimit: Field(20),
@@ -541,7 +549,7 @@ test(' Spec and Node operations', async (t) => {
 
     // 10 < threshold <= value = highLimit (should pass)
     const root2 = {
-      data: { value: Field(20) },
+      data: { owner, data: { value: Field(20) } },
       threshold: Field(18),
       lowLimit: Field(10),
       highLimit: Field(20),
@@ -552,7 +560,7 @@ test(' Spec and Node operations', async (t) => {
 
     // value <= lowLimit (should fail)
     const root3 = {
-      data: { value: Field(10) },
+      data: { owner, data: { value: Field(10) } },
       threshold: Field(18),
       lowLimit: Field(10),
       highLimit: Field(20),
@@ -563,7 +571,7 @@ test(' Spec and Node operations', async (t) => {
 
     // 10 < threshold <= value < highLimit (should fail)
     const root4 = {
-      data: { value: Field(19) },
+      data: { owner, data: { value: Field(19) } },
       threshold: Field(18),
       lowLimit: Field(10),
       highLimit: Field(20),

--- a/tests/program-with-proof.test.ts
+++ b/tests/program-with-proof.test.ts
@@ -57,7 +57,7 @@ await describe('program with proof credential', async () => {
     assert(proof, 'Proof should be generated');
 
     assert.deepStrictEqual(
-      proof.publicInput.targetAge,
+      proof.publicInput.claims.targetAge,
       Field(18),
       'Public input should match'
     );
@@ -105,7 +105,11 @@ async function createInvalidProofCredential(data: {
   age: Field;
   name: Bytes;
 }): Promise<UserInputs<typeof spec.inputs>['provedData']> {
-  let proof = await ProvedData.dummyProof({ owner }, { owner, data });
+  let context = Field(0);
+  let proof = await ProvedData.dummyProof(
+    { context, claims: { owner } },
+    { owner, data }
+  );
   return {
     credential: proof.publicOutput,
     private: { vk: inputVk, proof },

--- a/tests/program-with-proof.test.ts
+++ b/tests/program-with-proof.test.ts
@@ -9,14 +9,13 @@ import {
   type UserInputs,
 } from '../src/program-spec.ts';
 import { Credential } from '../src/credentials.ts';
-import { owner } from './test-utils.ts';
+import { createOwnerSignature, owner } from './test-utils.ts';
 
 const Bytes32 = Bytes(32);
 const InputData = { age: Field, name: Bytes32 };
 
 // TODO
 let context = Field(0);
-let ownerSignature = Signature.empty();
 
 // simple spec to create a proof credential that's used recursively
 const inputProofSpec = Spec(
@@ -46,6 +45,7 @@ const spec = Spec(
 );
 
 const program = createProgram(spec);
+let data = { age: Field(18), name: Bytes32.fromString('Alice') };
 
 await describe('program with proof credential', async () => {
   await test('compile program', async () => {
@@ -53,8 +53,11 @@ await describe('program with proof credential', async () => {
   });
 
   await test('run program with valid inputs', async () => {
-    let data = { age: Field(18), name: Bytes32.fromString('Alice') };
     let provedData = await createProofCredential(data);
+    let ownerSignature = createOwnerSignature(context, [
+      ProvedData,
+      provedData,
+    ]);
 
     const proof = await program.run({
       context,
@@ -78,8 +81,11 @@ await describe('program with proof credential', async () => {
   });
 
   await test('run program with invalid proof', async () => {
-    const data = { age: Field(18), name: Bytes32.fromString('Alice') };
     let provedData = await createInvalidProofCredential(data);
+    let ownerSignature = createOwnerSignature(context, [
+      ProvedData,
+      provedData,
+    ]);
 
     await assert.rejects(
       async () =>
@@ -100,6 +106,34 @@ await describe('program with proof credential', async () => {
       'Program should fail with invalid input'
     );
   });
+
+  await test('run program with invalid signature', async () => {
+    let provedData = await createProofCredential(data);
+    // changing the context makes the signature invalid
+    let invalidContext = context.add(1);
+    let ownerSignature = createOwnerSignature(invalidContext, [
+      ProvedData,
+      provedData,
+    ]);
+
+    await assert.rejects(
+      async () =>
+        await program.run({
+          context,
+          ownerSignature,
+          credentials: { provedData },
+          claims: { targetAge: Field(18) },
+        }),
+      (err) => {
+        assert(err instanceof Error, 'Should throw an Error');
+        assert(
+          err.message.includes('Invalid owner signature'),
+          'Error message should include unsatisfied constraint'
+        );
+        return true;
+      }
+    );
+  });
 });
 
 // helpers
@@ -110,7 +144,8 @@ async function createProofCredential(data: {
 }): Promise<UserInputs<typeof spec.inputs>['credentials']['provedData']> {
   let inputProof = await inputProgram.run({
     context,
-    ownerSignature,
+    // there is no credential, so no signature verification
+    ownerSignature: Signature.empty(),
     claims: { owner, data },
     credentials: {},
   });

--- a/tests/program-with-proof.test.ts
+++ b/tests/program-with-proof.test.ts
@@ -59,7 +59,8 @@ await describe('program with proof credential', async () => {
     const proof = await program.run({
       context,
       ownerSignature,
-      inputs: { provedData, targetAge: Field(18) },
+      credentials: { provedData },
+      claims: { targetAge: Field(18) },
     });
 
     assert(proof, 'Proof should be generated');
@@ -85,7 +86,8 @@ await describe('program with proof credential', async () => {
         await program.run({
           context,
           ownerSignature,
-          inputs: { provedData, targetAge: Field(18) },
+          credentials: { provedData },
+          claims: { targetAge: Field(18) },
         }),
       (err) => {
         assert(err instanceof Error, 'Should throw an Error');
@@ -105,11 +107,12 @@ await describe('program with proof credential', async () => {
 async function createProofCredential(data: {
   age: Field;
   name: Bytes;
-}): Promise<UserInputs<typeof spec.inputs>['inputs']['provedData']> {
+}): Promise<UserInputs<typeof spec.inputs>['credentials']['provedData']> {
   let inputProof = await inputProgram.run({
     context,
     ownerSignature,
-    inputs: { owner, data },
+    claims: { owner },
+    credentials: { data },
   });
   let proof = ProvedData.fromProof(inputProof);
   return {
@@ -121,7 +124,7 @@ async function createProofCredential(data: {
 async function createInvalidProofCredential(data: {
   age: Field;
   name: Bytes;
-}): Promise<UserInputs<typeof spec.inputs>['inputs']['provedData']> {
+}): Promise<UserInputs<typeof spec.inputs>['credentials']['provedData']> {
   let context = Field(0);
   let proof = await ProvedData.dummyProof(
     { context, claims: { owner } },

--- a/tests/program-with-proof.test.ts
+++ b/tests/program-with-proof.test.ts
@@ -20,7 +20,7 @@ let ownerSignature = Signature.empty();
 
 // simple spec to create a proof credential that's used recursively
 const inputProofSpec = Spec(
-  { owner: Input.claim(PublicKey), data: Input.private(InputData) },
+  { owner: Input.claim(PublicKey), data: Input.claim(InputData) },
   ({ owner, data }) => ({
     data: Operation.record({ owner, data }),
   })
@@ -111,8 +111,8 @@ async function createProofCredential(data: {
   let inputProof = await inputProgram.run({
     context,
     ownerSignature,
-    claims: { owner },
-    credentials: { data },
+    claims: { owner, data },
+    credentials: {},
   });
   let proof = ProvedData.fromProof(inputProof);
   return {
@@ -127,7 +127,7 @@ async function createInvalidProofCredential(data: {
 }): Promise<UserInputs<typeof spec.inputs>['credentials']['provedData']> {
   let context = Field(0);
   let proof = await ProvedData.dummyProof(
-    { context, claims: { owner } },
+    { context, claims: { owner, data } },
     { owner, data }
   );
   return {

--- a/tests/program.test.ts
+++ b/tests/program.test.ts
@@ -41,7 +41,7 @@ test('program with simple spec and signature credential', async (t) => {
     assert(proof, 'Proof should be generated');
 
     assert.deepStrictEqual(
-      proof.publicInput.targetAge,
+      proof.publicInput.claims.targetAge,
       Field(18),
       'Public input should match'
     );

--- a/tests/program.test.ts
+++ b/tests/program.test.ts
@@ -43,7 +43,8 @@ test('program with simple spec and signature credential', async (t) => {
     const proof = await program.run({
       context,
       ownerSignature,
-      inputs: { signedData, targetAge: Field(18) },
+      credentials: { signedData },
+      claims: { targetAge: Field(18) },
     });
 
     assert(proof, 'Proof should be generated');
@@ -69,7 +70,8 @@ test('program with simple spec and signature credential', async (t) => {
         await program.run({
           context,
           ownerSignature,
-          inputs: { signedData, targetAge: Field(18) },
+          credentials: { signedData },
+          claims: { targetAge: Field(18) },
         }),
       (err) => {
         assert(err instanceof Error, 'Should throw an Error');
@@ -96,7 +98,8 @@ test('program with simple spec and signature credential', async (t) => {
         await program.run({
           context,
           ownerSignature,
-          inputs: { signedData, targetAge: Field(18) },
+          credentials: { signedData },
+          claims: { targetAge: Field(18) },
         }),
       (err) => {
         assert(err instanceof Error, 'Should throw an Error');

--- a/tests/program.test.ts
+++ b/tests/program.test.ts
@@ -1,22 +1,25 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { Field, Bytes, Signature } from 'o1js';
+import { Field, Bytes } from 'o1js';
 import { createProgram } from '../src/program.ts';
 import { Input, Operation, Spec } from '../src/program-spec.ts';
-import { createSignatureCredential } from './test-utils.ts';
+import {
+  createOwnerSignature,
+  createSignatureCredential,
+} from './test-utils.ts';
 import { Credential } from '../src/credentials.ts';
 
 // TODO
 let context = Field(0);
-let ownerSignature = Signature.empty();
 
 test('program with simple spec and signature credential', async (t) => {
   const Bytes32 = Bytes(32);
   const InputData = { age: Field, name: Bytes32 };
+  const SignedData = Credential.signatureNative(InputData);
 
   const spec = Spec(
     {
-      signedData: Credential.signatureNative(InputData),
+      signedData: SignedData,
       targetAge: Input.claim(Field),
       targetName: Input.constant(Bytes32, Bytes32.fromString('Alice')),
     },
@@ -39,6 +42,10 @@ test('program with simple spec and signature credential', async (t) => {
   await t.test('run program with valid input', async () => {
     let data = { age: Field(18), name: Bytes32.fromString('Alice') };
     let signedData = createSignatureCredential(InputData, data);
+    let ownerSignature = createOwnerSignature(context, [
+      SignedData,
+      signedData,
+    ]);
 
     const proof = await program.run({
       context,
@@ -64,6 +71,10 @@ test('program with simple spec and signature credential', async (t) => {
   await t.test('run program with invalid age input', async () => {
     const data = { age: Field(20), name: Bytes32.fromString('Alice') };
     const signedData = createSignatureCredential(InputData, data);
+    let ownerSignature = createOwnerSignature(context, [
+      SignedData,
+      signedData,
+    ]);
 
     await assert.rejects(
       async () =>
@@ -92,6 +103,10 @@ test('program with simple spec and signature credential', async (t) => {
   await t.test('run program with invalid name input', async () => {
     const data = { age: Field(18), name: Bytes32.fromString('Bob') };
     const signedData = createSignatureCredential(InputData, data);
+    let ownerSignature = createOwnerSignature(context, [
+      SignedData,
+      signedData,
+    ]);
 
     await assert.rejects(
       async () =>

--- a/tests/program.test.ts
+++ b/tests/program.test.ts
@@ -1,10 +1,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { Field, Bytes } from 'o1js';
+import { Field, Bytes, Signature } from 'o1js';
 import { createProgram } from '../src/program.ts';
 import { Input, Operation, Spec } from '../src/program-spec.ts';
 import { createSignatureCredential } from './test-utils.ts';
 import { Credential } from '../src/credentials.ts';
+
+// TODO
+let context = Field(0);
+let ownerSignature = Signature.empty();
 
 test('program with simple spec and signature credential', async (t) => {
   const Bytes32 = Bytes(32);
@@ -36,7 +40,11 @@ test('program with simple spec and signature credential', async (t) => {
     let data = { age: Field(18), name: Bytes32.fromString('Alice') };
     let signedData = createSignatureCredential(InputData, data);
 
-    const proof = await program.run({ signedData, targetAge: Field(18) });
+    const proof = await program.run({
+      context,
+      ownerSignature,
+      inputs: { signedData, targetAge: Field(18) },
+    });
 
     assert(proof, 'Proof should be generated');
 
@@ -57,7 +65,12 @@ test('program with simple spec and signature credential', async (t) => {
     const signedData = createSignatureCredential(InputData, data);
 
     await assert.rejects(
-      async () => await program.run({ signedData, targetAge: Field(18) }),
+      async () =>
+        await program.run({
+          context,
+          ownerSignature,
+          inputs: { signedData, targetAge: Field(18) },
+        }),
       (err) => {
         assert(err instanceof Error, 'Should throw an Error');
         assert(
@@ -79,7 +92,12 @@ test('program with simple spec and signature credential', async (t) => {
     const signedData = createSignatureCredential(InputData, data);
 
     await assert.rejects(
-      async () => await program.run({ signedData, targetAge: Field(18) }),
+      async () =>
+        await program.run({
+          context,
+          ownerSignature,
+          inputs: { signedData, targetAge: Field(18) },
+        }),
       (err) => {
         assert(err instanceof Error, 'Should throw an Error');
         assert(

--- a/tests/serialize.test.ts
+++ b/tests/serialize.test.ts
@@ -128,7 +128,7 @@ test('Serialize Nodes', async (t) => {
     const rootNode: Node = {
       type: 'root',
       input: {
-        age: Input.private(Field),
+        age: Credential.none(Field),
         isAdmin: Input.claim(Bool),
       },
     };
@@ -140,14 +140,14 @@ test('Serialize Nodes', async (t) => {
     assert.deepStrictEqual(serialized, expected);
   });
 
-  await t.test('should serialize propery Node', () => {
+  await t.test('should serialize property Node', () => {
     const propertyNode: Node = {
       type: 'property',
       key: 'age',
       inner: {
         type: 'root',
         input: {
-          age: Input.private(Field),
+          age: Credential.none(Field),
           isAdmin: Input.claim(Bool),
         },
       },
@@ -289,12 +289,14 @@ test('serializeInput', async (t) => {
   });
 
   await t.test('should serialize private input', () => {
-    const input = Input.private(Field);
+    const input = Credential.none(Field);
 
     const serialized = serializeInput(input);
 
     const expected = {
-      type: 'private',
+      type: 'credential',
+      id: 'none',
+      private: { type: 'Undefined' },
       data: { type: 'Field' },
     };
     assert.deepStrictEqual(serialized, expected);
@@ -334,12 +336,14 @@ test('serializeInput', async (t) => {
       },
       score: UInt32,
     };
-    const input = Input.private(NestedInputData);
+    const input = Credential.none(NestedInputData);
 
     const serialized = serializeInput(input);
 
     const expected = {
-      type: 'private',
+      type: 'credential',
+      id: 'none',
+      private: { type: 'Undefined' },
       data: {
         personal: {
           age: { type: 'Field' },
@@ -365,7 +369,7 @@ test('convertSpecToSerializable', async (t) => {
   await t.test('should serialize a simple Spec', () => {
     const spec = Spec(
       {
-        age: Input.private(Field),
+        age: Credential.none(Field),
         isAdmin: Input.claim(Bool),
         maxAge: Input.constant(Field, Field(100)),
       },
@@ -379,7 +383,12 @@ test('convertSpecToSerializable', async (t) => {
 
     const expected = {
       inputs: {
-        age: { type: 'private', data: { type: 'Field' } },
+        age: {
+          type: 'credential',
+          id: 'none',
+          private: { type: 'Undefined' },
+          data: { type: 'Field' },
+        },
         isAdmin: { type: 'public', data: { type: 'Bool' } },
         maxAge: { type: 'constant', data: { type: 'Field' }, value: '100' },
       },
@@ -390,8 +399,12 @@ test('convertSpecToSerializable', async (t) => {
             type: 'lessThan',
             left: {
               type: 'property',
-              key: 'age',
-              inner: { type: 'root' },
+              key: 'data',
+              inner: {
+                type: 'property',
+                key: 'age',
+                inner: { type: 'root' },
+              },
             },
             right: {
               type: 'property',
@@ -407,8 +420,12 @@ test('convertSpecToSerializable', async (t) => {
         },
         data: {
           type: 'property',
-          key: 'age',
-          inner: { type: 'root' },
+          key: 'data',
+          inner: {
+            type: 'property',
+            key: 'age',
+            inner: { type: 'root' },
+          },
         },
       },
     };
@@ -490,8 +507,8 @@ test('convertSpecToSerializable', async (t) => {
   await t.test('should serialize a Spec with nested operations', () => {
     const spec = Spec(
       {
-        field1: Input.private(Field),
-        field2: Input.private(Field),
+        field1: Credential.none(Field),
+        field2: Credential.none(Field),
         zeroField: Input.constant(Field, Field(0)),
       },
       ({ field1, field2, zeroField }) => ({
@@ -506,8 +523,18 @@ test('convertSpecToSerializable', async (t) => {
     const serialized = convertSpecToSerializable(spec);
     const expected = {
       inputs: {
-        field1: { type: 'private', data: { type: 'Field' } },
-        field2: { type: 'private', data: { type: 'Field' } },
+        field1: {
+          type: 'credential',
+          id: 'none',
+          private: { type: 'Undefined' },
+          data: { type: 'Field' },
+        },
+        field2: {
+          type: 'credential',
+          id: 'none',
+          private: { type: 'Undefined' },
+          data: { type: 'Field' },
+        },
         zeroField: { type: 'constant', data: { type: 'Field' }, value: '0' },
       },
       logic: {
@@ -517,21 +544,33 @@ test('convertSpecToSerializable', async (t) => {
             type: 'lessThan',
             left: {
               type: 'property',
-              key: 'field1',
-              inner: { type: 'root' },
+              key: 'data',
+              inner: {
+                type: 'property',
+                key: 'field1',
+                inner: { type: 'root' },
+              },
             },
             right: {
               type: 'property',
-              key: 'field2',
-              inner: { type: 'root' },
+              key: 'data',
+              inner: {
+                type: 'property',
+                key: 'field2',
+                inner: { type: 'root' },
+              },
             },
           },
           right: {
             type: 'equals',
             left: {
               type: 'property',
-              key: 'field1',
-              inner: { type: 'root' },
+              key: 'data',
+              inner: {
+                type: 'property',
+                key: 'field1',
+                inner: { type: 'root' },
+              },
             },
             right: {
               type: 'property',
@@ -542,8 +581,12 @@ test('convertSpecToSerializable', async (t) => {
         },
         data: {
           type: 'property',
-          key: 'field2',
-          inner: { type: 'root' },
+          key: 'data',
+          inner: {
+            type: 'property',
+            key: 'field2',
+            inner: { type: 'root' },
+          },
         },
       },
     };
@@ -554,7 +597,7 @@ test('convertSpecToSerializable', async (t) => {
 test('Serialize and deserialize spec with hash', async (t) => {
   const spec = Spec(
     {
-      age: Input.private(Field),
+      age: Credential.none(Field),
       isAdmin: Input.claim(Bool),
       ageLimit: Input.constant(Field, Field(100)),
     },

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -1,8 +1,12 @@
-import { PrivateKey, Signature } from 'o1js';
+import { Field, PrivateKey, PublicKey, Signature } from 'o1js';
 import { type NestedProvableFor } from '../src/nested.ts';
-import { HashedCredential } from '../src/credentials.ts';
+import {
+  type CredentialType,
+  HashedCredential,
+  signCredential,
+} from '../src/credentials.ts';
 
-export { createSignatureCredential, owner, ownerKey };
+export { createSignatureCredential, createOwnerSignature, owner, ownerKey };
 
 const { publicKey: owner, privateKey: ownerKey } = PrivateKey.randomKeypair();
 
@@ -17,4 +21,24 @@ function createSignatureCredential<Data>(
     credential: { owner, data },
     private: { issuerPublicKey: issuer.publicKey, issuerSignature: signature },
   };
+}
+
+function createOwnerSignature<Private, Data>(
+  context: Field,
+  ...credentials: [
+    CredentialType<any, Private, Data>,
+    {
+      credential: { owner: PublicKey; data: Data };
+      private: Private;
+    }
+  ][]
+) {
+  // TODO support many credentials
+  let [credentialType, credential] = credentials[0]!;
+  return signCredential(ownerKey, {
+    context,
+    credentialType: credentialType,
+    credential: credential.credential,
+    privateInput: credential.private,
+  });
 }

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -1,17 +1,18 @@
 import { PrivateKey, Signature } from 'o1js';
-import { NestedProvable } from '../src/nested.ts';
-import { Credential } from '../src/credentials.ts';
+import { type NestedProvableFor } from '../src/nested.ts';
+import { HashedCredential } from '../src/credentials.ts';
 
 export { createSignatureCredential, owner, ownerKey };
 
 const { publicKey: owner, privateKey: ownerKey } = PrivateKey.randomKeypair();
 
-function createSignatureCredential<Data>(type: NestedProvable, data: Data) {
+function createSignatureCredential<Data>(
+  type: NestedProvableFor<Data>,
+  data: Data
+) {
   let issuer = PrivateKey.randomKeypair();
-  let signature = Signature.create(
-    issuer.privateKey,
-    NestedProvable.get(Credential.withOwner(type)).toFields({ owner, data })
-  );
+  let credHash = HashedCredential(type).hash({ owner, data });
+  let signature = Signature.create(issuer.privateKey, [credHash.hash]);
   return {
     credential: { owner, data },
     private: { issuerPublicKey: issuer.publicKey, issuerSignature: signature },


### PR DESCRIPTION
closes #19

follows #34 in implementing verification of credentials and owner signature

TODOs left for later PR:
* owner and issuers are not yet fed to the application circuit
* no function for computing `context` yet, currently just set to 0 in tests