### PR TITLE
Serialize recursive credentials, and requests

### DIFF
--- a/src/deserialize-spec.ts
+++ b/src/deserialize-spec.ts
@@ -6,9 +6,9 @@ import {
   UInt64,
   PublicKey,
   Signature,
-  Provable,
   type ProvablePure,
   assert,
+  Bytes,
 } from 'o1js';
 import { Claim, Constant, type Input, Node, Spec } from './program-spec.ts';
 import type {
@@ -160,11 +160,18 @@ function deserializeNode(input: any, node: any): Node {
   }
 }
 
-function deserializeProvableType(type: {
-  type: O1jsTypeName | 'Constant';
-}): Provable<any> {
+function deserializeProvableType(
+  type:
+    | {
+        type: O1jsTypeName | 'Constant';
+      }
+    | { type: 'Bytes'; size: number }
+): ProvableType<any> {
   if (type.type === 'Constant') {
     return ProvableType.constant((type as any).value);
+  }
+  if (type.type === 'Bytes') {
+    return Bytes(type.size);
   }
   let result = supportedTypes[type.type];
   assert(result !== undefined, `Unsupported provable type: ${type.type}`);
@@ -187,6 +194,8 @@ function deserializeProvable(type: string, value: string): any {
       return PublicKey.fromJSON(value);
     case 'Signature':
       return Signature.fromJSON(value);
+    case 'Bytes':
+      return Bytes.fromHex(value);
     default:
       throw Error(`Unsupported provable type: ${type}`);
   }

--- a/src/nested.ts
+++ b/src/nested.ts
@@ -33,6 +33,8 @@ const NestedProvable = {
       return ProvableType.fromValue(value);
     } catch {
       // case 2: value is a record of values from provable types
+      if (typeof value === 'string') return String as any;
+
       assertIsObject(value);
       return Object.fromEntries(
         Object.entries(value).map(([key, value]) => [

--- a/src/o1js-missing.ts
+++ b/src/o1js-missing.ts
@@ -30,7 +30,7 @@ const ProvableType = {
   },
 
   // TODO o1js should make sure this is possible for _all_ provable types
-  fromValue<T>(value: T): Provable<T> {
+  fromValue<T>(value: T): ProvableType<T> {
     if (value === undefined) return Undefined as any;
     if (value instanceof Field) return Field as any;
     if (value instanceof Bool) return Bool as any;
@@ -40,9 +40,8 @@ const ProvableType = {
       'Encountered provable value without a constructor: Cannot obtain provable type.'
     );
     let constructor = value.constructor;
-    let type = ProvableType.get(constructor);
-    assertIsProvable(type);
-    return type;
+    assertIsProvable(ProvableType.get(constructor));
+    return constructor as any;
   },
 
   synthesize<T>(type_: ProvableType<T>): T {

--- a/src/serialize-spec.ts
+++ b/src/serialize-spec.ts
@@ -191,7 +191,7 @@ function serializeNode(node: Node): any {
 type SerializedType =
   | { _type: O1jsTypeName }
   | { _type: 'Struct'; properties: SerializedNestedType }
-  | { _type: 'Constant'; size: number }
+  | { _type: 'Constant'; value: unknown }
   | { _type: 'Bytes'; size: number }
   | { _type: 'Proof'; proof: Record<string, any> }
   | { _type: 'String' };

--- a/src/serialize-spec.ts
+++ b/src/serialize-spec.ts
@@ -268,8 +268,8 @@ function serializeNestedProvable(
     return serializeProvableType(type);
   }
 
-  if (typeof type === 'string') return String as any;
-  if ((type as any) === String) return { _type: 'String' };
+  if (typeof type === 'string' || (type as any) === String)
+    return { _type: 'String' };
 
   if (typeof type === 'object' && type !== null) {
     const serializedObject: Record<string, any> = {};

--- a/src/serialize-spec.ts
+++ b/src/serialize-spec.ts
@@ -206,11 +206,10 @@ function serializeProvableType(type: ProvableType<any>): SerializedType {
     };
     return { _type: 'Proof', proof };
   }
-  // TODO: handle case when type is a Struct
-  if ((type as any)._isStruct) {
+  let _type = mapProvableTypeToName.get(type);
+  if (_type === undefined && (type as any)._isStruct) {
     return serializeStruct(type as Struct<any>);
   }
-  let _type = mapProvableTypeToName.get(type);
   assert(
     _type !== undefined,
     `serializeProvableType: Unsupported provable type: ${type}`

--- a/src/serialize-spec.ts
+++ b/src/serialize-spec.ts
@@ -84,9 +84,9 @@ function serializeInputs(inputs: Record<string, Input>): Record<string, any> {
   return Object.fromEntries(
     // sort by keys so we always get the same serialization for the same spec
     // will be important for hashing
-    Object.entries(inputs)
-      .sort((a, b) => a[0].localeCompare(b[0]))
-      .map(([key, input]) => [key, serializeInput(input)])
+    Object.keys(inputs)
+      .sort()
+      .map((key) => [key, serializeInput(inputs[key]!)])
   );
 }
 
@@ -276,7 +276,7 @@ function serializeNestedProvable(
     // sort by keys so we always get the same serialization for the same spec
     // will be important for hashing
     let keys = Object.keys(type);
-    if (reorderKeys) keys = keys.sort((a, b) => a.localeCompare(b));
+    if (reorderKeys) keys = keys.sort();
 
     for (const key of keys) {
       serializedObject[key] = serializeNestedProvable(type[key]!, reorderKeys);
@@ -301,7 +301,7 @@ function serializeNestedProvableTypeAndValue(t: {
   }
   return Object.fromEntries(
     Object.keys(t.type)
-      .sort((a, b) => a.localeCompare(b))
+      .sort()
       .map((key) => {
         assert(key in t.value, `Missing value for key ${key}`);
         return [
@@ -339,15 +339,4 @@ async function validateSpecHash(
   const { spec, hash } = JSON.parse(serializedSpecWithHash);
   const recomputedHash = await hashSpec(spec);
   return hash === recomputedHash;
-}
-
-function serializeObjectSorted<T, S>(
-  obj: Record<string, T>,
-  serialize: (t: T) => S
-): Record<string, S> {
-  return Object.fromEntries(
-    Object.entries(obj)
-      .sort((a, b) => a[0].localeCompare(b[0]))
-      .map(([key, value]) => [key, serialize(value)])
-  );
 }

--- a/src/serialize-spec.ts
+++ b/src/serialize-spec.ts
@@ -255,12 +255,15 @@ function serializeStruct(type: Struct<any>): SerializedType {
 
   for (let key in value) {
     let type = NestedProvable.fromValue(value[key]);
-    properties[key] = serializeNestedProvable(type);
+    properties[key] = serializeNestedProvable(type, false);
   }
   return { _type: 'Struct', properties };
 }
 
-function serializeNestedProvable(type: NestedProvable): SerializedNestedType {
+function serializeNestedProvable(
+  type: NestedProvable,
+  reorderKeys = true
+): SerializedNestedType {
   if (ProvableType.isProvableType(type)) {
     return serializeProvableType(type);
   }
@@ -272,10 +275,11 @@ function serializeNestedProvable(type: NestedProvable): SerializedNestedType {
     const serializedObject: Record<string, any> = {};
     // sort by keys so we always get the same serialization for the same spec
     // will be important for hashing
-    for (const [key, value] of Object.entries(type).sort((a, b) =>
-      a[0].localeCompare(b[0])
-    )) {
-      serializedObject[key] = serializeNestedProvable(value);
+    let keys = Object.keys(type);
+    if (reorderKeys) keys = keys.sort((a, b) => a.localeCompare(b));
+
+    for (const key of keys) {
+      serializedObject[key] = serializeNestedProvable(type[key]!, reorderKeys);
     }
     return serializedObject;
   }

--- a/tests/deserialize.test.ts
+++ b/tests/deserialize.test.ts
@@ -32,7 +32,6 @@ import {
 } from '../src/deserialize-spec.ts';
 import { Credential } from '../src/credential-index.ts';
 import { withOwner } from '../src/credential.ts';
-import { deserialize } from 'node:v8';
 
 test('Deserialize Spec', async (t) => {
   await t.test('deserializeProvable', async (t) => {

--- a/tests/deserialize.test.ts
+++ b/tests/deserialize.test.ts
@@ -738,14 +738,21 @@ test('deserializeSpec', async (t) => {
         deserialized.inputs.provedData?.type,
         originalSpec.inputs.provedData.type
       );
-
-      assert.deepStrictEqual(
-        deserialized.inputs.provedData.witness,
-        originalSpec.inputs.provedData.witness
-      );
       assert.deepStrictEqual(
         deserialized.inputs.provedData.data,
         originalSpec.inputs.provedData.data
+      );
+
+      let DeserializedProof: typeof DynamicProof = (
+        originalSpec.inputs.provedData.witness as any
+      ).proof;
+      assert.deepStrictEqual(
+        DeserializedProof.featureFlags,
+        RecursiveProof.featureFlags
+      );
+      assert.deepStrictEqual(
+        DeserializedProof.maxProofsVerified,
+        RecursiveProof.maxProofsVerified
       );
     }
   );

--- a/tests/presentation-with-proof.test.ts
+++ b/tests/presentation-with-proof.test.ts
@@ -56,32 +56,32 @@ let requestInitial = PresentationRequest.noContext(spec, {
 let json = PresentationRequest.toJSON(requestInitial);
 
 // wallet: deserialize and compile request
-// TODO: Information about Recursive program is lost here, this seems to create some problem
 let deserialized = PresentationRequest.fromJSON<typeof requestInitial>(json);
 
-console.log('Original:', requestInitial.spec.inputs.provedData.witness);
-console.log('Deserialized:', deserialized.spec.inputs.provedData.witness);
+// for (let i = 0; i < analyze1.rows; i++) {
+//   assert.deepStrictEqual(
+//     analyze1.gates[i],
+//     analyze2.gates[i],
+//     `Gates should match at row ${i}`
+//   );
+// }
 
-let analyze1 = await createProgram(
-  requestInitial.spec
-).program.analyzeMethods();
-let analyze2 = await createProgram(deserialized.spec).program.analyzeMethods();
-console.log('Original:', analyze1);
-console.log('Deserialized:', analyze2);
-
-assert.deepStrictEqual(
-  deserialized.spec.inputs.provedData.data,
-  requestInitial.spec.inputs.provedData.data
-);
-assert.deepStrictEqual(
-  deserialized.spec.inputs.provedData.witness,
-  requestInitial.spec.inputs.provedData.witness
-);
-assert.deepStrictEqual(deserialized.spec.logic, requestInitial.spec.logic);
-
-let request = await Presentation.compile(requestInitial);
+let request = await Presentation.compile(deserialized);
 
 await describe('program with proof credential', async () => {
+  await test('program is deserialized correctly', async () => {
+    let program1 = createProgram(requestInitial.spec);
+    let analyze1 = await program1.program.analyzeMethods();
+    let program2 = createProgram(deserialized.spec);
+    let analyze2 = await program2.program.analyzeMethods();
+
+    assert.deepStrictEqual(
+      analyze1.run?.digest,
+      analyze2.run?.digest,
+      'Same circuit digest'
+    );
+  });
+
   await test('compile program', async () => {
     await request.program.compile();
   });

--- a/tests/presentation-with-proof.test.ts
+++ b/tests/presentation-with-proof.test.ts
@@ -58,7 +58,28 @@ let json = PresentationRequest.toJSON(requestInitial);
 // wallet: deserialize and compile request
 // TODO: Information about Recursive program is lost here, this seems to create some problem
 let deserialized = PresentationRequest.fromJSON<typeof requestInitial>(json);
-let request = await Presentation.compile(deserialized);
+
+console.log('Original:', requestInitial.spec.inputs.provedData.witness);
+console.log('Deserialized:', deserialized.spec.inputs.provedData.witness);
+
+let analyze1 = await createProgram(
+  requestInitial.spec
+).program.analyzeMethods();
+let analyze2 = await createProgram(deserialized.spec).program.analyzeMethods();
+console.log('Original:', analyze1);
+console.log('Deserialized:', analyze2);
+
+assert.deepStrictEqual(
+  deserialized.spec.inputs.provedData.data,
+  requestInitial.spec.inputs.provedData.data
+);
+assert.deepStrictEqual(
+  deserialized.spec.inputs.provedData.witness,
+  requestInitial.spec.inputs.provedData.witness
+);
+assert.deepStrictEqual(deserialized.spec.logic, requestInitial.spec.logic);
+
+let request = await Presentation.compile(requestInitial);
 
 await describe('program with proof credential', async () => {
   await test('compile program', async () => {

--- a/tests/presentation-with-proof.test.ts
+++ b/tests/presentation-with-proof.test.ts
@@ -57,15 +57,6 @@ let json = PresentationRequest.toJSON(requestInitial);
 
 // wallet: deserialize and compile request
 let deserialized = PresentationRequest.fromJSON<typeof requestInitial>(json);
-
-// for (let i = 0; i < analyze1.rows; i++) {
-//   assert.deepStrictEqual(
-//     analyze1.gates[i],
-//     analyze2.gates[i],
-//     `Gates should match at row ${i}`
-//   );
-// }
-
 let request = await Presentation.compile(deserialized);
 
 await describe('program with proof credential', async () => {

--- a/tests/presentation-with-proof.test.ts
+++ b/tests/presentation-with-proof.test.ts
@@ -53,7 +53,12 @@ const spec = Spec(
 let requestInitial = PresentationRequest.noContext(spec, {
   targetAge: Field(18),
 });
-let request = await Presentation.compile(requestInitial);
+let json = PresentationRequest.toJSON(requestInitial);
+
+// wallet: deserialize and compile request
+// TODO: Information about Recursive program is lost here, this seems to create some problem
+let deserialized = PresentationRequest.fromJSON<typeof requestInitial>(json);
+let request = await Presentation.compile(deserialized);
 
 await describe('program with proof credential', async () => {
   await test('compile program', async () => {

--- a/tests/presentation.test.ts
+++ b/tests/presentation.test.ts
@@ -8,12 +8,10 @@ import { Presentation, PresentationRequest } from '../src/presentation.ts';
 
 test('program with simple spec and signature credential', async (t) => {
   const Bytes32 = Bytes(32);
-  const InputData = { age: Field, name: Bytes32 };
-  const SignedData = Credential.Simple(InputData);
 
   const spec = Spec(
     {
-      signedData: SignedData,
+      signedData: Credential.Simple({ age: Field, name: Bytes32 }),
       targetAge: Claim(Field),
       targetName: Constant(Bytes32, Bytes32.fromString('Alice')),
     },
@@ -31,7 +29,11 @@ test('program with simple spec and signature credential', async (t) => {
   let requestInitial = PresentationRequest.noContext(spec, {
     targetAge: Field(18),
   });
-  let request = await Presentation.compile(requestInitial);
+  let json = PresentationRequest.toJSON(requestInitial);
+
+  // wallet: deserialize and compile request
+  let deserialized = PresentationRequest.fromJSON<typeof requestInitial>(json);
+  let request = await Presentation.compile(deserialized);
 
   await t.test('compile program', async () => {
     assert(

--- a/tests/serialize.test.ts
+++ b/tests/serialize.test.ts
@@ -16,16 +16,16 @@ import { Credential } from '../src/credential-index.ts';
 
 test('Serialize Inputs', async (t) => {
   await t.test('should serialize basic types correctly', () => {
-    assert.deepStrictEqual(serializeProvableType(Field), { type: 'Field' });
-    assert.deepStrictEqual(serializeProvableType(Bool), { type: 'Bool' });
-    assert.deepStrictEqual(serializeProvableType(UInt8), { type: 'UInt8' });
-    assert.deepStrictEqual(serializeProvableType(UInt32), { type: 'UInt32' });
-    assert.deepStrictEqual(serializeProvableType(UInt64), { type: 'UInt64' });
+    assert.deepStrictEqual(serializeProvableType(Field), { _type: 'Field' });
+    assert.deepStrictEqual(serializeProvableType(Bool), { _type: 'Bool' });
+    assert.deepStrictEqual(serializeProvableType(UInt8), { _type: 'UInt8' });
+    assert.deepStrictEqual(serializeProvableType(UInt32), { _type: 'UInt32' });
+    assert.deepStrictEqual(serializeProvableType(UInt64), { _type: 'UInt64' });
     assert.deepStrictEqual(serializeProvableType(PublicKey), {
-      type: 'PublicKey',
+      _type: 'PublicKey',
     });
     assert.deepStrictEqual(serializeProvableType(Signature), {
-      type: 'Signature',
+      _type: 'Signature',
     });
   });
 
@@ -35,23 +35,21 @@ test('Serialize Inputs', async (t) => {
 
   await t.test('should serialize simple provable types (nested)', () => {
     assert.deepStrictEqual(serializeNestedProvable(Field), {
-      type: 'Field',
+      _type: 'Field',
     });
-    assert.deepStrictEqual(serializeNestedProvable(Bool), { type: 'Bool' });
-    assert.deepStrictEqual(serializeNestedProvable(UInt8), {
-      type: 'UInt8',
-    });
+    assert.deepStrictEqual(serializeNestedProvable(Bool), { _type: 'Bool' });
+    assert.deepStrictEqual(serializeNestedProvable(UInt8), { _type: 'UInt8' });
     assert.deepStrictEqual(serializeNestedProvable(UInt32), {
-      type: 'UInt32',
+      _type: 'UInt32',
     });
     assert.deepStrictEqual(serializeNestedProvable(UInt64), {
-      type: 'UInt64',
+      _type: 'UInt64',
     });
     assert.deepStrictEqual(serializeNestedProvable(PublicKey), {
-      type: 'PublicKey',
+      _type: 'PublicKey',
     });
     assert.deepStrictEqual(serializeNestedProvable(Signature), {
-      type: 'Signature',
+      _type: 'Signature',
     });
   });
 
@@ -65,10 +63,10 @@ test('Serialize Inputs', async (t) => {
     };
 
     assert.deepStrictEqual(serializeNestedProvable(nestedType), {
-      field: { type: 'Field' },
+      field: { _type: 'Field' },
       nested: {
-        bool: { type: 'Bool' },
-        uint: { type: 'UInt32' },
+        bool: { _type: 'Bool' },
+        uint: { _type: 'UInt32' },
       },
     });
   });
@@ -87,22 +85,22 @@ test('Serialize Inputs', async (t) => {
     };
 
     assert.deepStrictEqual(serializeNestedProvable(complexType), {
-      simpleField: { type: 'Field' },
+      simpleField: { _type: 'Field' },
       nestedObject: {
-        publicKey: { type: 'PublicKey' },
-        signature: { type: 'Signature' },
+        publicKey: { _type: 'PublicKey' },
+        signature: { _type: 'Signature' },
         deeplyNested: {
-          bool: { type: 'Bool' },
-          uint64: { type: 'UInt64' },
+          bool: { _type: 'Bool' },
+          uint64: { _type: 'UInt64' },
         },
       },
     });
   });
 
   await t.test('should throw an error for unsupported types', () => {
-    assert.throws(() => serializeNestedProvable('unsupported' as any), {
+    assert.throws(() => serializeNestedProvable(123 as any), {
       name: 'Error',
-      message: 'Unsupported type in NestedProvable: unsupported',
+      message: 'Unsupported type in NestedProvable: 123',
     });
   });
 });
@@ -115,10 +113,7 @@ test('Serialize Nodes', async (t) => {
 
     const expected = {
       type: 'constant',
-      data: {
-        type: 'Field',
-        value: '123',
-      },
+      data: { _type: 'Field', value: '123' },
     };
 
     assert.deepEqual(serialized, expected);
@@ -170,8 +165,8 @@ test('Serialize Nodes', async (t) => {
 
     const expected = {
       type: 'equals',
-      left: { type: 'constant', data: { type: 'Field', value: '10' } },
-      right: { type: 'constant', data: { type: 'Field', value: '10' } },
+      left: { type: 'constant', data: { _type: 'Field', value: '10' } },
+      right: { type: 'constant', data: { _type: 'Field', value: '10' } },
     };
 
     assert.deepStrictEqual(serialized, expected);
@@ -187,8 +182,8 @@ test('Serialize Nodes', async (t) => {
 
     const expected = {
       type: 'lessThan',
-      left: { type: 'constant', data: { type: 'UInt32', value: '5' } },
-      right: { type: 'constant', data: { type: 'UInt32', value: '10' } },
+      left: { type: 'constant', data: { _type: 'UInt32', value: '5' } },
+      right: { type: 'constant', data: { _type: 'UInt32', value: '10' } },
     };
 
     assert.deepStrictEqual(serialized, expected);
@@ -204,8 +199,8 @@ test('Serialize Nodes', async (t) => {
 
     const expected = {
       type: 'lessThanEq',
-      left: { type: 'constant', data: { type: 'UInt64', value: '15' } },
-      right: { type: 'constant', data: { type: 'UInt64', value: '15' } },
+      left: { type: 'constant', data: { _type: 'UInt64', value: '15' } },
+      right: { type: 'constant', data: { _type: 'UInt64', value: '15' } },
     };
 
     assert.deepStrictEqual(serialized, expected);
@@ -221,8 +216,8 @@ test('Serialize Nodes', async (t) => {
 
     const expected = {
       type: 'and',
-      left: { type: 'constant', data: { type: 'Bool', value: 'true' } },
-      right: { type: 'constant', data: { type: 'Bool', value: 'false' } },
+      left: { type: 'constant', data: { _type: 'Bool', value: 'true' } },
+      right: { type: 'constant', data: { _type: 'Bool', value: 'false' } },
     };
 
     assert.deepStrictEqual(serialized, expected);
@@ -238,8 +233,8 @@ test('Serialize Nodes', async (t) => {
 
     const expected = {
       type: 'or',
-      left: { type: 'constant', data: { type: 'Bool', value: 'true' } },
-      right: { type: 'constant', data: { type: 'Bool', value: 'false' } },
+      left: { type: 'constant', data: { _type: 'Bool', value: 'true' } },
+      right: { type: 'constant', data: { _type: 'Bool', value: 'false' } },
     };
 
     assert.deepStrictEqual(serialized, expected);
@@ -255,8 +250,8 @@ test('Serialize Nodes', async (t) => {
 
     const expected = {
       type: 'add',
-      left: { type: 'constant', data: { type: 'Field', value: '5' } },
-      right: { type: 'constant', data: { type: 'Field', value: '10' } },
+      left: { type: 'constant', data: { _type: 'Field', value: '5' } },
+      right: { type: 'constant', data: { _type: 'Field', value: '10' } },
     };
 
     assert.deepStrictEqual(serialized, expected);
@@ -272,8 +267,8 @@ test('Serialize Nodes', async (t) => {
 
     const expected = {
       type: 'sub',
-      left: { type: 'constant', data: { type: 'Field', value: '15' } },
-      right: { type: 'constant', data: { type: 'Field', value: '7' } },
+      left: { type: 'constant', data: { _type: 'Field', value: '15' } },
+      right: { type: 'constant', data: { _type: 'Field', value: '7' } },
     };
 
     assert.deepStrictEqual(serialized, expected);
@@ -289,8 +284,8 @@ test('Serialize Nodes', async (t) => {
 
     const expected = {
       type: 'mul',
-      left: { type: 'constant', data: { type: 'Field', value: '3' } },
-      right: { type: 'constant', data: { type: 'Field', value: '4' } },
+      left: { type: 'constant', data: { _type: 'Field', value: '3' } },
+      right: { type: 'constant', data: { _type: 'Field', value: '4' } },
     };
 
     assert.deepStrictEqual(serialized, expected);
@@ -306,8 +301,8 @@ test('Serialize Nodes', async (t) => {
 
     const expected = {
       type: 'div',
-      left: { type: 'constant', data: { type: 'Field', value: '20' } },
-      right: { type: 'constant', data: { type: 'Field', value: '5' } },
+      left: { type: 'constant', data: { _type: 'Field', value: '20' } },
+      right: { type: 'constant', data: { _type: 'Field', value: '5' } },
     };
 
     assert.deepStrictEqual(serialized, expected);
@@ -323,7 +318,7 @@ test('Serialize Nodes', async (t) => {
 
     const expected = {
       type: 'not',
-      inner: { type: 'constant', data: { type: 'Bool', value: 'true' } },
+      inner: { type: 'constant', data: { _type: 'Bool', value: 'true' } },
     };
 
     assert.deepStrictEqual(serialized, expected);
@@ -339,7 +334,7 @@ test('Serialize Nodes', async (t) => {
 
     const expected = {
       type: 'hash',
-      inner: { type: 'constant', data: { type: 'Field', value: '123' } },
+      inner: { type: 'constant', data: { _type: 'Field', value: '123' } },
     };
 
     assert.deepStrictEqual(serialized, expected);
@@ -356,9 +351,9 @@ test('Serialize Nodes', async (t) => {
 
     const expected = {
       type: 'ifThenElse',
-      condition: { type: 'constant', data: { type: 'Bool', value: 'true' } },
-      thenNode: { type: 'constant', data: { type: 'Field', value: '1' } },
-      elseNode: { type: 'constant', data: { type: 'Field', value: '0' } },
+      condition: { type: 'constant', data: { _type: 'Bool', value: 'true' } },
+      thenNode: { type: 'constant', data: { _type: 'Field', value: '1' } },
+      elseNode: { type: 'constant', data: { _type: 'Field', value: '0' } },
     };
 
     assert.deepStrictEqual(serialized, expected);
@@ -375,8 +370,8 @@ test('Serialize Nodes', async (t) => {
     const expected = {
       type: 'record',
       data: {
-        field1: { type: 'constant', data: { type: 'Field', value: '123' } },
-        field2: { type: 'constant', data: { type: 'Bool', value: 'true' } },
+        field1: { type: 'constant', data: { _type: 'Field', value: '123' } },
+        field2: { type: 'constant', data: { _type: 'Bool', value: 'true' } },
       },
     };
 
@@ -401,13 +396,13 @@ test('Serialize Nodes', async (t) => {
       type: 'and',
       left: {
         type: 'lessThan',
-        left: { type: 'constant', data: { type: 'Field', value: '5' } },
-        right: { type: 'constant', data: { type: 'Field', value: '10' } },
+        left: { type: 'constant', data: { _type: 'Field', value: '5' } },
+        right: { type: 'constant', data: { _type: 'Field', value: '10' } },
       },
       right: {
         type: 'equals',
-        left: { type: 'constant', data: { type: 'Bool', value: 'true' } },
-        right: { type: 'constant', data: { type: 'Bool', value: 'true' } },
+        left: { type: 'constant', data: { _type: 'Bool', value: 'true' } },
+        right: { type: 'constant', data: { _type: 'Bool', value: 'true' } },
       },
     };
 
@@ -423,7 +418,7 @@ test('serializeInput', async (t) => {
 
     const expected = {
       type: 'constant',
-      data: { type: 'Field' },
+      data: { _type: 'Field' },
       value: '42',
     };
 
@@ -437,7 +432,7 @@ test('serializeInput', async (t) => {
 
     const expected = {
       type: 'public',
-      data: { type: 'Field' },
+      data: { _type: 'Field' },
     };
 
     assert.deepStrictEqual(serialized, expected);
@@ -451,8 +446,8 @@ test('serializeInput', async (t) => {
     const expected = {
       type: 'credential',
       id: 'none',
-      witness: { type: 'Undefined' },
-      data: { type: 'Field' },
+      witness: { _type: 'Undefined' },
+      data: { _type: 'Field' },
     };
     assert.deepStrictEqual(serialized, expected);
   });
@@ -468,12 +463,12 @@ test('serializeInput', async (t) => {
       id: 'signature-native',
       witness: {
         type: { type: 'Constant', value: 'simple' },
-        issuer: { type: 'PublicKey' },
-        issuerSignature: { type: 'Signature' },
+        issuer: { _type: 'PublicKey' },
+        issuerSignature: { _type: 'Signature' },
       },
       data: {
-        age: { type: 'Field' },
-        isAdmin: { type: 'Bool' },
+        age: { _type: 'Field' },
+        isAdmin: { _type: 'Bool' },
       },
     };
 
@@ -495,13 +490,13 @@ test('serializeInput', async (t) => {
     const expected = {
       type: 'credential',
       id: 'none',
-      witness: { type: 'Undefined' },
+      witness: { _type: 'Undefined' },
       data: {
         personal: {
-          age: { type: 'Field' },
-          id: { type: 'UInt64' },
+          age: { _type: 'Field' },
+          id: { _type: 'UInt64' },
         },
-        score: { type: 'UInt32' },
+        score: { _type: 'UInt32' },
       },
     };
 
@@ -538,11 +533,11 @@ test('convertSpecToSerializable', async (t) => {
         age: {
           type: 'credential',
           id: 'none',
-          witness: { type: 'Undefined' },
-          data: { type: 'Field' },
+          witness: { _type: 'Undefined' },
+          data: { _type: 'Field' },
         },
-        isAdmin: { type: 'public', data: { type: 'Bool' } },
-        maxAge: { type: 'constant', data: { type: 'Field' }, value: '100' },
+        isAdmin: { type: 'public', data: { _type: 'Bool' } },
+        maxAge: { type: 'constant', data: { _type: 'Field' }, value: '100' },
       },
       logic: {
         assert: {
@@ -608,14 +603,14 @@ test('convertSpecToSerializable', async (t) => {
           id: 'signature-native',
           witness: {
             type: { type: 'Constant', value: 'simple' },
-            issuer: { type: 'PublicKey' },
-            issuerSignature: { type: 'Signature' },
+            issuer: { _type: 'PublicKey' },
+            issuerSignature: { _type: 'Signature' },
           },
           data: {
-            field: { type: 'Field' },
+            field: { _type: 'Field' },
           },
         },
-        zeroField: { type: 'constant', data: { type: 'Field' }, value: '0' },
+        zeroField: { type: 'constant', data: { _type: 'Field' }, value: '0' },
       },
       logic: {
         assert: {
@@ -675,16 +670,16 @@ test('convertSpecToSerializable', async (t) => {
         field1: {
           type: 'credential',
           id: 'none',
-          witness: { type: 'Undefined' },
-          data: { type: 'Field' },
+          witness: { _type: 'Undefined' },
+          data: { _type: 'Field' },
         },
         field2: {
           type: 'credential',
           id: 'none',
-          witness: { type: 'Undefined' },
-          data: { type: 'Field' },
+          witness: { _type: 'Undefined' },
+          data: { _type: 'Field' },
         },
-        zeroField: { type: 'constant', data: { type: 'Field' }, value: '0' },
+        zeroField: { type: 'constant', data: { _type: 'Field' }, value: '0' },
       },
       logic: {
         assert: {


### PR DESCRIPTION
closes #28

- serialize `Bytes`
- serialize proofs
- => serialize all types of credentials/presentations
- check that we can run presentation tests on reserialized versions of the presentation request, simulating real-world flow.