### PR TITLE
Nullifier example and polishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,6 @@ jobs:
           npm ci
           npm run build --if-present
           npm test
+          npm run examples
         env:
           CI: true

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -13,30 +13,30 @@ import { validateCredential } from '../src/credential-index.ts';
 
 // example schema of the credential, which has enough entropy to be hashed into a unique id
 const Bytes32 = Bytes(32);
-const Bytes128 = Bytes(128);
+const Bytes16 = Bytes(16); // 16 bytes = 128 bits = enough entropy
 
 const Data = {
   nationality: Bytes32,
-  id: Bytes128,
+  id: Bytes16,
 };
 
 // ---------------------------------------------
 // ISSUER: issue a signed credential to the owner
 let data = {
   nationality: Bytes32.fromString('United States of America'),
-  id: Bytes128.random(),
+  id: Bytes16.random(),
 };
 let credential = Credential.sign(issuerKey, { owner, data });
-// TODO: serialize the credential to send it to the owner wallet
-console.log('✅ ISSUER: issued credential:', credential);
+let credentialJson = Credential.toJSON(credential);
+
+console.log('✅ ISSUER: issued credential:', credentialJson);
 
 // ---------------------------------------------
 // WALLET: deserialize, validate and store the credential
-let storedCredential = credential;
+let storedCredential = Credential.fromJSON(credentialJson);
 
-// TODO: this validation should be generic: it should obtain the CredentialType from the storedCredential.id,
-// and use the `verify()` method on CredentialType
 await validateCredential(storedCredential);
+
 console.log('✅ WALLET: imported and validated credential');
 
 // ---------------------------------------------

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -56,8 +56,7 @@ const spec = Spec(
     ),
     // we expose a unique hash of the credential data, as nullifier
     data: Operation.record({
-      // TODO make this take a list of fields, and add the appId
-      nullifier: Operation.hash(signedData),
+      nullifier: Operation.hash(signedData, appId),
     }),
   })
 );

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -10,18 +10,17 @@ import {
 } from '../src/index.ts';
 import { issuerKey, owner, ownerKey } from '../tests/test-utils.ts';
 import { validateCredential } from '../src/credential-index.ts';
+import { array } from '../src/o1js-missing.ts';
 
 // example schema of the credential, which has enough entropy to be hashed into a unique id
 const Bytes32 = Bytes(32);
 const Bytes16 = Bytes(16); // 16 bytes = 128 bits = enough entropy
 
-const Data = {
-  nationality: Bytes32,
-  id: Bytes16,
-};
+const Data = { nationality: Bytes32, id: Bytes16 };
 
 // ---------------------------------------------
 // ISSUER: issue a signed credential to the owner
+
 let data = {
   nationality: Bytes32.fromString('United States of America'),
   id: Bytes16.random(),
@@ -33,6 +32,7 @@ console.log('✅ ISSUER: issued credential:', credentialJson);
 
 // ---------------------------------------------
 // WALLET: deserialize, validate and store the credential
+
 let storedCredential = Credential.fromJSON(credentialJson);
 
 await validateCredential(storedCredential);
@@ -41,18 +41,19 @@ console.log('✅ WALLET: imported and validated credential');
 
 // ---------------------------------------------
 // VERIFIER: request a presentation
+
 const spec = Spec(
   {
     signedData: Credential.Simple(Data), // schema needed here!
-    targetNationality: Claim(Bytes32),
+    targetNationalities: Claim(array(Bytes32, 3)), // TODO would make more sense as dynamic array
     appId: Claim(Bytes32),
   },
-  ({ signedData, targetNationality, appId }) => ({
+  ({ signedData, targetNationalities, appId }) => ({
     // we assert that the owner has the target nationality
     // TODO: add a one-of-many operation to make this more interesting
-    assert: Operation.equals(
+    assert: Operation.equalsOneOf(
       Operation.property(signedData, 'nationality'),
-      targetNationality
+      targetNationalities
     ),
     // we expose a unique hash of the credential data, as nullifier
     data: Operation.record({
@@ -61,15 +62,19 @@ const spec = Spec(
   })
 );
 
+const targetNationalities = ['United States of America', 'Canada', 'Mexico'];
+
 let request = PresentationRequest.noContext(spec, {
-  targetNationality: Bytes32.fromString('United States of America'),
-  appId: Bytes32.fromString('my-app-id'),
+  targetNationalities: targetNationalities.map((s) => Bytes32.fromString(s)),
+  appId: Bytes32.fromString('my-app-id:123'),
 });
 let requestJson = PresentationRequest.toJSON(request);
+
 console.log('✅ VERIFIER: created presentation request:', requestJson);
 
 // ---------------------------------------------
 // WALLET: deserialize request and create presentation
+
 console.time('compile');
 let deserialized = PresentationRequest.fromJSON<typeof request>(requestJson);
 let compiled = await Presentation.compile(deserialized);
@@ -82,10 +87,12 @@ let presentation = await Presentation.create(ownerKey, {
 });
 console.timeEnd('create');
 // TODO: to send the presentation back we need to serialize it as well
+
 console.log('✅ WALLET: created presentation:', presentation);
 
 // ---------------------------------------------
 // VERIFIER: verify the presentation, and check that the nullifier was not used yet
+
 let existingNullifiers = new Set([0x13c43f30n, 0x370f3473n, 0xe1fe0cdan]);
 
 // TODO: claims and other I/O values should be plain JS types

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -15,18 +15,16 @@ import { hashCredential } from '../src/credential.ts';
 const Bytes32 = Bytes(32);
 const Bytes128 = Bytes(128);
 
-// TODO: if we reorder id, nationality, it stops working because serialization changes the order!
-// that shouldn't be the case, changing the order was a bad idea
 const Data = {
-  id: Bytes128,
   nationality: Bytes32,
+  id: Bytes128,
 };
 
 // ---------------------------------------------
 // ISSUER: issue a signed credential to the owner
 let data = {
-  id: Bytes128.random(),
   nationality: Bytes32.fromString('United States of America'),
+  id: Bytes128.random(),
 };
 let credential = Credential.sign(issuerKey, { owner, data });
 // TODO: serialize the credential to send it to the owner wallet

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -1,0 +1,103 @@
+import { Bytes, Provable } from 'o1js';
+import {
+  Spec,
+  Operation,
+  Claim,
+  Credential,
+  Presentation,
+  PresentationRequest,
+  assert,
+} from '../src/index.ts';
+import { issuerKey, owner, ownerKey } from '../tests/test-utils.ts';
+import { hashCredential } from '../src/credential.ts';
+
+// example schema of the credential, which has enough entropy to be hashed into a unique id
+const Bytes32 = Bytes(32);
+const Bytes128 = Bytes(128);
+
+// TODO: if we reorder id, nationality, it stops working because serialization changes the order!
+// that shouldn't be the case, changing the order was a bad idea
+const Data = {
+  id: Bytes128,
+  nationality: Bytes32,
+};
+
+// ---------------------------------------------
+// ISSUER: issue a signed credential to the owner
+let data = {
+  id: Bytes128.random(),
+  nationality: Bytes32.fromString('United States of America'),
+};
+let credential = Credential.sign(issuerKey, { owner, data });
+// TODO: serialize the credential to send it to the owner wallet
+
+// ---------------------------------------------
+// WALLET: deserialize, validate and store the credential
+let storedCredential = credential;
+
+// TODO: this validation should be generic: it should obtain the CredentialType from the storedCredential.id,
+// and use the `verify()` method on CredentialType
+console.log('Stored credential:', storedCredential);
+let credHash = hashCredential(Data, storedCredential.credential);
+let ok = storedCredential.witness.issuerSignature.verify(
+  storedCredential.witness.issuer,
+  [credHash.hash]
+);
+ok.assertTrue('Invalid signature when importing credential');
+
+// ---------------------------------------------
+// VERIFIER: request a presentation
+const spec = Spec(
+  {
+    signedData: Credential.Simple(Data), // schema needed here!
+    targetNationality: Claim(Bytes32),
+    appId: Claim(Bytes32),
+  },
+  ({ signedData, targetNationality, appId }) => ({
+    // we assert that the owner has the target nationality
+    // TODO: add a one-of-many operation to make this more interesting
+    assert: Operation.equals(
+      Operation.property(signedData, 'nationality'),
+      targetNationality
+    ),
+    // we expose a unique hash of the credential data, as nullifier
+    data: Operation.record({
+      // TODO make this take a list of fields, and add the appId
+      nullifier: Operation.hash(signedData),
+    }),
+  })
+);
+
+let request = PresentationRequest.noContext(spec, {
+  targetNationality: Bytes32.fromString('United States of America'),
+  appId: Bytes32.fromString('my-app-id'),
+});
+let requestJson = PresentationRequest.toJSON(request);
+
+// ---------------------------------------------
+// WALLET: deserialize request and create presentation
+console.time('compile');
+let deserialized = PresentationRequest.fromJSON<typeof request>(requestJson);
+let compiled = await Presentation.compile(deserialized);
+console.timeEnd('compile');
+
+console.time('create');
+let presentation = await Presentation.create(ownerKey, {
+  request: compiled,
+  credentials: [storedCredential],
+});
+console.timeEnd('create');
+// TODO: to send the presentation back we need to serialize it as well
+
+// ---------------------------------------------
+// VERIFIER: verify the presentation, and check that the nullifier was not used yet
+let existingNullifiers = new Set([0x13c43f30n, 0x370f3473n, 0xe1fe0cdan]);
+
+// TODO: claims and other I/O values should be plain JS types
+let { nullifier } = presentation.outputClaim;
+assert(
+  !existingNullifiers.has(nullifier.toBigInt()),
+  'Nullifier should be unique'
+);
+
+// TODO: implement verification

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format": "prettier --write --ignore-unknown **/*",
     "test": "node --test --experimental-strip-types --no-warnings {tests,src}/**/*.test.ts",
     "test-one": "node --enable-source-maps --test --experimental-strip-types --no-warnings",
+    "examples": "node --test --experimental-strip-types --no-warnings examples/*.eg.ts",
     "extension:dev": "vite build --config browser-extension/vite.config.js --watch",
     "extension:build": "vite build --config browser-extension/vite.config.js"
   },

--- a/src/credential-index.ts
+++ b/src/credential-index.ts
@@ -1,9 +1,30 @@
-import { createUnsigned, Unsigned } from './credential.ts';
-import { createSigned, Signed } from './credential-signed.ts';
 import { type PublicKey } from 'o1js';
-import { Recursive } from './credential-recursive.ts';
+import {
+  createUnsigned,
+  type CredentialSpec,
+  type CredentialType,
+  hashCredential,
+  type StoredCredential,
+  Unsigned,
+} from './credential.ts';
+import {
+  createSigned,
+  Signed,
+  type Witness as SignedWitness,
+} from './credential-signed.ts';
+import {
+  Recursive,
+  type Witness as RecursiveWitness,
+} from './credential-recursive.ts';
+import { assert, hasProperty } from './util.ts';
+import {
+  type InferNestedProvable,
+  NestedProvable,
+  type NestedProvablePure,
+} from './nested.ts';
+import { assertPure } from './o1js-missing.ts';
 
-export { Credential };
+export { Credential, validateCredential };
 
 /**
  * A credential is a generic piece of data (the "attributes") along with an owner represented by a public key.
@@ -25,3 +46,45 @@ const Credential = {
    */
   unsigned: createUnsigned,
 };
+
+// validating generic credential
+
+type Witness = SignedWitness | RecursiveWitness;
+
+async function validateCredential(
+  credential: StoredCredential<unknown, unknown, unknown>
+) {
+  assert(knownWitness(credential.witness), `Unknown credential type`);
+
+  // TODO: this is brittle. probably data type should be part of metadata.
+  let data = NestedProvable.get(
+    NestedProvable.fromValue(credential.credential.data)
+  );
+  assertPure(data);
+  let spec = getCredentialSpec(credential.witness)(data);
+
+  let credHash = hashCredential(data, credential.credential);
+  await spec.verifyOutsideCircuit(credential.witness, credHash);
+}
+
+const witnessTypes = new Set<unknown>([
+  'simple',
+  'recursive',
+] satisfies Witness['type'][]);
+
+function knownWitness(witness: unknown): witness is Witness {
+  return hasProperty(witness, 'type') && witnessTypes.has(witness.type);
+}
+
+function getCredentialSpec<W extends Witness>(
+  witness: W
+): <DataType extends NestedProvablePure>(
+  dataType: DataType
+) => CredentialSpec<CredentialType, W, InferNestedProvable<DataType>> {
+  switch (witness.type) {
+    case 'simple':
+      return Credential.Simple as any;
+    case 'recursive':
+      return Credential.Recursive.Generic as any;
+  }
+}

--- a/src/credential-recursive.ts
+++ b/src/credential-recursive.ts
@@ -21,7 +21,7 @@ import {
 } from './nested.ts';
 import { prefixes } from './constants.ts';
 import {
-  type CredentialType,
+  type CredentialSpec,
   type Credential,
   type StoredCredential,
   HashableCredential,
@@ -49,14 +49,14 @@ function Recursive<
 >(
   Proof: typeof DynamicProof<Input, Credential<Data>>,
   dataType: DataType
-): CredentialType<'proof', Witness<Data, Input>, Data> {
+): CredentialSpec<'recursive', Witness<Data, Input>, Data> {
   // TODO annoying that this cast doesn't work without overriding the type
   let data: NestedProvablePureFor<Data> = dataType as any;
   const credentialType = HashableCredential(data);
 
   return {
     type: 'credential',
-    id: 'proof',
+    credentialType: 'recursive',
     witness: {
       type: ProvableType.constant('recursive' as const),
       vk: VerificationKey,

--- a/src/credential-signed.ts
+++ b/src/credential-signed.ts
@@ -26,7 +26,7 @@ type Metadata = undefined;
 type Signed<Data> = StoredCredential<Data, Witness, Metadata>;
 
 const Signed = defineCredential({
-  id: 'signature-native',
+  credentialType: 'simple',
   witness: {
     type: ProvableType.constant('simple' as const),
     issuer: PublicKey,

--- a/src/credential-signed.ts
+++ b/src/credential-signed.ts
@@ -38,6 +38,10 @@ const Signed = defineCredential({
     let ok = issuerSignature.verify(issuer, [credHash.hash]);
     ok.assertTrue('Invalid signature');
   },
+  async verifyOutsideCircuit({ issuer, issuerSignature }, credHash) {
+    let ok = issuerSignature.verify(issuer, [credHash.hash]);
+    ok.assertTrue('Invalid signature');
+  },
 
   // issuer == issuer public key
   issuer({ issuer }) {

--- a/src/credential.ts
+++ b/src/credential.ts
@@ -19,8 +19,8 @@ import { zip } from './util.ts';
 
 export {
   type Credential,
+  type CredentialSpec,
   type CredentialType,
-  type CredentialId,
   type CredentialInputs,
   type CredentialOutputs,
   hashCredential,
@@ -43,7 +43,7 @@ type Credential<Data> = { owner: PublicKey; data: Data };
 /**
  * The different types of credential we currently support.
  */
-type CredentialId = 'none' | 'signature-native' | 'proof';
+type CredentialType = 'unsigned' | 'simple' | 'recursive';
 
 /**
  * A credential type is:
@@ -53,13 +53,13 @@ type CredentialId = 'none' | 'signature-native' | 'proof';
  * - a function `verify(...)` that asserts the credential is valid
  * - a function `issuer(...)` that derives a commitment to the "issuer" of the credential, e.g. a public key for signed credentials
  */
-type CredentialType<
-  Id extends CredentialId = CredentialId,
+type CredentialSpec<
+  Type extends CredentialType = CredentialType,
   Witness = any,
   Data = any
 > = {
   type: 'credential';
-  id: Id;
+  credentialType: Type;
   witness: NestedProvableFor<Witness>;
   data: NestedProvablePureFor<Data>;
 
@@ -93,7 +93,7 @@ type CredentialInputs = {
   ownerSignature: Signature;
 
   credentials: {
-    credentialType: CredentialType;
+    spec: CredentialSpec;
     credential: Credential<any>;
     witness: any;
   }[];
@@ -116,22 +116,18 @@ function verifyCredentials({
   credentials,
 }: CredentialInputs): CredentialOutputs {
   // pack credentials in hashes
-  let credHashes = credentials.map(({ credentialType: { data }, credential }) =>
+  let credHashes = credentials.map(({ spec: { data }, credential }) =>
     hashCredential(data, credential)
   );
 
   // verify each credential using its own verification method
-  zip(credentials, credHashes).forEach(
-    ([{ credentialType, witness }, credHash]) => {
-      credentialType.verify(witness, credHash);
-    }
-  );
+  zip(credentials, credHashes).forEach(([{ spec, witness }, credHash]) => {
+    spec.verify(witness, credHash);
+  });
 
   // create issuer hashes for each credential
   // TODO would be nice to make this a `Hashed<Issuer>` over a more informative `Issuer` type, for easier use in the app circuit
-  let issuers = credentials.map(({ credentialType, witness }) =>
-    credentialType.issuer(witness)
-  );
+  let issuers = credentials.map(({ spec, witness }) => spec.issuer(witness));
 
   // assert that all credentials have the same owner, and determine that owner
   let owner: undefined | PublicKey;
@@ -166,7 +162,7 @@ function signCredentials<Private, Data>(
   ownerKey: PrivateKey,
   context: Field,
   ...credentials: {
-    credentialType: CredentialType<any, Private, Data>;
+    credentialType: CredentialSpec<any, Private, Data>;
     credential: Credential<Data>;
     witness: Private;
   }[]
@@ -182,10 +178,10 @@ function signCredentials<Private, Data>(
 }
 
 function defineCredential<
-  Id extends CredentialId,
+  Id extends CredentialType,
   PrivateType extends NestedProvable
 >(config: {
-  id: Id;
+  credentialType: Id;
   witness: PrivateType;
 
   verify<Data>(
@@ -197,14 +193,14 @@ function defineCredential<
 }) {
   return function credential<DataType extends NestedProvablePure>(
     dataType: DataType
-  ): CredentialType<
+  ): CredentialSpec<
     Id,
     InferNestedProvable<PrivateType>,
     InferNestedProvable<DataType>
   > {
     return {
       type: 'credential',
-      id: config.id,
+      credentialType: config.credentialType,
       witness: config.witness as any,
       data: dataType as any,
       verify: config.verify,
@@ -217,7 +213,7 @@ function defineCredential<
 type Unsigned<Data> = StoredCredential<Data, undefined, undefined>;
 
 const Unsigned = defineCredential({
-  id: 'none',
+  credentialType: 'unsigned',
   witness: Undefined,
 
   // do nothing

--- a/src/deserialize-spec.ts
+++ b/src/deserialize-spec.ts
@@ -198,7 +198,6 @@ function deserializeNode(
         data: deserializedData,
       };
     default:
-      node.type satisfies never;
       throw Error(`Invalid node type: ${node.type}`);
   }
 }

--- a/src/deserialize-spec.ts
+++ b/src/deserialize-spec.ts
@@ -24,7 +24,7 @@ import {
   type O1jsTypeName,
   type SerializedProvableType,
 } from './serialize-spec.ts';
-import { type CredentialId } from './credential.ts';
+import { type CredentialType } from './credential.ts';
 import { Credential } from './credential-index.ts';
 import { ProvableType } from './o1js-missing.ts';
 import { PresentationRequest } from './presentation.ts';
@@ -91,18 +91,18 @@ function deserializeInput(input: any): Input {
     case 'public':
       return Claim(deserializeNestedProvablePure(input.data));
     case 'credential': {
-      let id: CredentialId = input.id;
+      let credentialType: CredentialType = input.credentialType;
       let data = deserializeNestedProvablePure(input.data);
-      switch (id) {
-        case 'signature-native':
+      switch (credentialType) {
+        case 'simple':
           return Credential.Simple(data);
-        case 'none':
+        case 'unsigned':
           return Credential.Unsigned(data);
-        case 'proof':
+        case 'recursive':
           let proof = deserializeProvableType(input.witness.proof) as any;
           return Credential.Recursive(proof, data);
         default:
-          throw Error(`Unsupported credential id: ${id}`);
+          throw Error(`Unsupported credential id: ${credentialType}`);
       }
     }
     default:

--- a/src/deserialize-spec.ts
+++ b/src/deserialize-spec.ts
@@ -71,18 +71,21 @@ function deserializeInputContext(context: {
 }) {
   return {
     type: context.type as 'zk-app' | 'https',
-    presentationCircuitVKHash: deserializeProvable(
-      'Field',
-      context.presentationCircuitVKHash.value
-    ),
+    presentationCircuitVKHash: deserializeProvable({
+      _type: 'Field',
+      value: context.presentationCircuitVKHash.value,
+    }),
     action:
       context.type === 'zk-app'
-        ? deserializeProvable(
-            'Field',
-            (context.action as { _type: string; value: string }).value
-          )
+        ? deserializeProvable({
+            _type: 'Field',
+            value: (context.action as { _type: string; value: string }).value,
+          })
         : (context.action as string),
-    serverNonce: deserializeProvable('Field', context.serverNonce.value),
+    serverNonce: deserializeProvable({
+      _type: 'Field',
+      value: context.serverNonce.value,
+    }),
   };
 }
 

--- a/src/deserialize-spec.ts
+++ b/src/deserialize-spec.ts
@@ -38,6 +38,7 @@ export {
   deserializeProvable,
   deserializeNestedProvable,
   deserializePresentationRequest,
+  deserializeNestedProvableValue,
 };
 
 function deserializePresentationRequest(request: any): PresentationRequest {
@@ -278,20 +279,24 @@ function deserializeNestedProvablePure(type: any): NestedProvablePure {
   throw Error(`Invalid type in NestedProvablePure: ${type}`);
 }
 
-function deserializeNestedProvableValue(type: any): any {
-  if (typeof type === 'object' && type !== null) {
-    if ('_type' in type) {
+function deserializeNestedProvableValue(value: any): any {
+  if (typeof value === 'string') return value;
+
+  if (typeof value === 'object' && value !== null) {
+    if ('_type' in value) {
       // basic provable type
-      return deserializeProvable(type._type, type.value);
+      return deserializeProvable(value._type, value.value);
     } else {
       // nested object
       const result: Record<string, any> = {};
-      for (const [key, value] of Object.entries(type)) {
-        result[key] = deserializeNestedProvableValue(value);
+      for (let [key, v] of Object.entries(value)) {
+        result[key] = deserializeNestedProvableValue(v);
       }
       return result;
     }
   }
+
+  throw Error(`Invalid nested provable value: ${value}`);
 }
 
 function replaceNull(obj: Record<string, any>): Record<string, any> {

--- a/src/deserialize-spec.ts
+++ b/src/deserialize-spec.ts
@@ -156,8 +156,14 @@ function deserializeNode(input: any, node: any): Node {
         left: deserializeNode(input, node.left),
         right: deserializeNode(input, node.right),
       };
-    case 'not':
     case 'hash':
+      let result: Node = {
+        type: node.type,
+        inputs: node.inputs.map((i: any) => deserializeNode(input, i)),
+      };
+      if (node.prefix !== null) result.prefix = node.prefix;
+      return result;
+    case 'not':
       return {
         type: node.type,
         inner: deserializeNode(input, node.inner),

--- a/src/deserialize-spec.ts
+++ b/src/deserialize-spec.ts
@@ -87,7 +87,7 @@ function deserializeInput(input: any): Input {
     case 'constant':
       return Constant(
         deserializeProvableType(input.data),
-        deserializeProvable(input.data)
+        deserializeProvable({ _type: input.data._type, value: input.value })
       );
     case 'claim':
       return Claim(deserializeNestedProvablePure(input.data));

--- a/src/deserialize-spec.ts
+++ b/src/deserialize-spec.ts
@@ -89,7 +89,7 @@ function deserializeInput(input: any): Input {
         deserializeProvableType(input.data),
         deserializeProvable(input.data._type, input.value)
       );
-    case 'public':
+    case 'claim':
       return Claim(deserializeNestedProvablePure(input.data));
     case 'credential': {
       let credentialType: CredentialType = input.credentialType;
@@ -111,6 +111,7 @@ function deserializeInput(input: any): Input {
   }
 }
 
+function deserializeNode(input: any, node: any): Node;
 function deserializeNode(
   input: any,
   node: { type: Node['type'] } & Record<string, any>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-// run with node --experimental-strip-types
-import './program-spec.ts';
-import './program.ts';
-import './types.ts';
+export { Spec, Operation, Claim, Constant } from './program-spec.ts';
+export { Credential } from './credential-index.ts';
+export { Presentation, PresentationRequest } from './presentation.ts';
+export { assert } from './util.ts';

--- a/src/nested.ts
+++ b/src/nested.ts
@@ -3,7 +3,7 @@
  * wrap types in `Struct` and similar.
  */
 import { type InferProvable, Provable, type ProvablePure, Struct } from 'o1js';
-import { type ProvablePureType, ProvableType } from './o1js-missing.ts';
+import { array, type ProvablePureType, ProvableType } from './o1js-missing.ts';
 import { assertIsObject } from './util.ts';
 
 export { NestedProvable };
@@ -34,6 +34,9 @@ const NestedProvable = {
     } catch {
       // case 2: value is a record of values from provable types
       if (typeof value === 'string') return String as any;
+
+      if (Array.isArray(value))
+        return array(NestedProvable.fromValue(value[0]), value.length) as any;
 
       assertIsObject(value);
       return Object.fromEntries(

--- a/src/o1js-missing.ts
+++ b/src/o1js-missing.ts
@@ -123,7 +123,7 @@ type ToProvable<A extends WithProvable<any>> = A extends {
 type InferProvableType<T extends ProvableType> = InferProvable<ToProvable<T>>;
 
 // temporary, until we land `StaticArray`
-// this is copied from o1js: https://github.com/o1-labs/o1js
+// this is copied from o1js and then modified: https://github.com/o1-labs/o1js
 // License here: https://github.com/o1-labs/o1js/blob/main/LICENSE
 function array<A extends ProvableType<any>>(elementType: A, length: number) {
   type T = InferProvable<A>;

--- a/src/presentation.ts
+++ b/src/presentation.ts
@@ -8,7 +8,7 @@ import {
 import { createProgram, type Program } from './program.ts';
 import {
   signCredentials,
-  type CredentialType,
+  type CredentialSpec,
   type StoredCredential,
 } from './credential.ts';
 import { assert } from './util.ts';
@@ -100,7 +100,7 @@ async function createPresentation<
   let { program } = await Presentation.compile(request);
 
   let credentialsNeeded = Object.entries(request.spec.inputs).filter(
-    (c): c is [string, CredentialType] => c[1].type === 'credential'
+    (c): c is [string, CredentialSpec] => c[1].type === 'credential'
   );
   let credentialsUsed = pickCredentials(
     credentialsNeeded.map(([key]) => key),

--- a/src/program-spec.ts
+++ b/src/program-spec.ts
@@ -25,8 +25,8 @@ import {
   type NestedProvablePureFor,
 } from './nested.ts';
 import {
+  type CredentialSpec,
   type CredentialType,
-  type CredentialId,
   type Credential,
   type CredentialInputs,
   withOwner,
@@ -145,7 +145,7 @@ type Constant<Data> = {
 type Claim<Data> = { type: 'claim'; data: NestedProvablePureFor<Data> };
 
 type Input<Data = any> =
-  | CredentialType<CredentialId, any, Data>
+  | CredentialSpec<CredentialType, any, Data>
   | Constant<Data>
   | Claim<Data>;
 
@@ -602,7 +602,7 @@ function extractCredentialInputs(
     if (input.type === 'credential') {
       let value: any = credentials[key];
       credentialInputs.push({
-        credentialType: input,
+        spec: input,
         credential: value.credential,
         witness: value.witness,
       });
@@ -693,16 +693,16 @@ type MapToDataInput<T extends Record<string, Input>> = {
 
 type ToClaim<T extends Input> = T extends Claim<infer Data> ? Data : never;
 
-type ToCredential<T extends Input> = T extends CredentialType<
-  CredentialId,
+type ToCredential<T extends Input> = T extends CredentialSpec<
+  CredentialType,
   infer Witness,
   infer Data
 >
   ? { credential: Credential<Data>; witness: Witness }
   : never;
 
-type ToDataInput<T extends Input> = T extends CredentialType<
-  CredentialId,
+type ToDataInput<T extends Input> = T extends CredentialSpec<
+  CredentialType,
   any,
   infer Data
 >

--- a/src/program-spec.ts
+++ b/src/program-spec.ts
@@ -245,11 +245,11 @@ function evalNode<Data>(root: object, node: Node<Data>): Data {
       let inner = evalNode(root, node.inner);
       return inner.not() as Data;
     }
-    // TODO: handle composite types
+    // TODO: list of inputs
     case 'hash': {
       let inner = evalNode(root, node.inner);
-      let innerFields = inner.toFields();
-      let hash = Poseidon.hash(innerFields);
+      let innerType = NestedProvable.get(NestedProvable.fromValue(inner));
+      let hash = Poseidon.hash(innerType.toFields(inner));
       return hash as Data;
     }
     case 'ifThenElse': {

--- a/src/serialize-spec.ts
+++ b/src/serialize-spec.ts
@@ -17,6 +17,7 @@ import {
   Struct,
 } from 'o1js';
 import { assert } from './util.ts';
+import type { StoredCredential } from './credential.ts';
 
 // Supported o1js base types
 const supportedTypes = {
@@ -51,6 +52,7 @@ export {
   serializeSpec,
   validateSpecHash,
   serializePresentationRequest,
+  serializeNestedProvableValue,
 };
 
 function serializePresentationRequest(request: PresentationRequest) {
@@ -287,6 +289,8 @@ function serializeNestedProvableTypeAndValue(t: {
   if (ProvableType.isProvableType(t.type)) {
     return serializeProvable(t.value);
   }
+  if (typeof t.type === 'string' || (t.type as any) === String) return t.value;
+
   return Object.fromEntries(
     Object.keys(t.type).map((key) => {
       assert(key in t.value, `Missing value for key ${key}`);

--- a/src/serialize-spec.ts
+++ b/src/serialize-spec.ts
@@ -250,11 +250,14 @@ function serializeProvableType(type: ProvableType<any>): SerializedType {
   return { _type };
 }
 
-function serializeProvable(value: any): { _type: string; value: string } {
+function serializeProvable(value: any): { _type: string; value: any } {
   let typeClass = ProvableType.fromValue(value);
   let { _type } = serializeProvableType(typeClass);
   if (_type === 'Bytes') {
     return { _type, value: (value as Bytes).toHex() };
+  }
+  if (_type === 'Array') {
+    return { _type, value: value.map((x: any) => serializeProvable(x)) };
   }
   switch (typeClass) {
     case Bool: {

--- a/src/serialize-spec.ts
+++ b/src/serialize-spec.ts
@@ -108,7 +108,7 @@ function serializeInput(input: Input): any {
       }
       case 'claim': {
         return {
-          type: 'public',
+          type: 'claim',
           data: serializeNestedProvable(input.data),
         };
       }

--- a/src/serialize-spec.ts
+++ b/src/serialize-spec.ts
@@ -161,6 +161,11 @@ function serializeNode(node: Node): any {
         right: serializeNode(node.right),
       };
     case 'hash':
+      return {
+        type: node.type,
+        inputs: node.inputs.map(serializeNode),
+        prefix: node.prefix ?? null,
+      };
     case 'not':
       return {
         type: node.type,

--- a/src/serialize-spec.ts
+++ b/src/serialize-spec.ts
@@ -17,7 +17,6 @@ import {
   Struct,
 } from 'o1js';
 import { assert } from './util.ts';
-import type { StoredCredential } from './credential.ts';
 
 // Supported o1js base types
 const supportedTypes = {

--- a/src/serialize-spec.ts
+++ b/src/serialize-spec.ts
@@ -114,7 +114,7 @@ function serializeInput(input: Input): any {
       }
     }
   }
-  throw new Error('Invalid input type');
+  throw Error('Invalid input type');
 }
 
 function serializeNode(node: Node): object {
@@ -197,6 +197,8 @@ function serializeNode(node: Node): object {
         data: serializedData,
       };
     }
+    default:
+      throw Error(`Invalid node type: ${(node as Node).type}`);
   }
 }
 

--- a/src/serialize-spec.ts
+++ b/src/serialize-spec.ts
@@ -92,7 +92,7 @@ function serializeInput(input: Input): any {
       case 'credential': {
         return {
           type: 'credential',
-          id: input.id,
+          credentialType: input.credentialType,
           witness: serializeNestedProvable(input.witness),
           data: serializeNestedProvable(input.data),
         };

--- a/tests/deserialize.test.ts
+++ b/tests/deserialize.test.ts
@@ -36,7 +36,7 @@ import { withOwner } from '../src/credential.ts';
 test('Deserialize Spec', async (t) => {
   await t.test('deserializeProvable', async (t) => {
     await t.test('Field', () => {
-      const deserialized = deserializeProvable('Field', '42');
+      const deserialized = deserializeProvable({ _type: 'Field', value: '42' });
       assert(deserialized instanceof Field, 'Should be instance of Field');
       assert.strictEqual(
         deserialized.toString(),
@@ -46,11 +46,17 @@ test('Deserialize Spec', async (t) => {
     });
 
     await t.test('Bool', () => {
-      const deserializedTrue = deserializeProvable('Bool', 'true');
+      const deserializedTrue = deserializeProvable({
+        _type: 'Bool',
+        value: 'true',
+      });
       assert(deserializedTrue instanceof Bool, 'Should be instance of Bool');
       assert.strictEqual(deserializedTrue.toBoolean(), true, 'Should be true');
 
-      const deserializedFalse = deserializeProvable('Bool', 'false');
+      const deserializedFalse = deserializeProvable({
+        _type: 'Bool',
+        value: 'false',
+      });
       assert(deserializedFalse instanceof Bool, 'Should be instance of Bool');
       assert.strictEqual(
         deserializedFalse.toBoolean(),
@@ -60,7 +66,10 @@ test('Deserialize Spec', async (t) => {
     });
 
     await t.test('UInt8', () => {
-      const deserialized = deserializeProvable('UInt8', '255');
+      const deserialized = deserializeProvable({
+        _type: 'UInt8',
+        value: '255',
+      });
       assert(deserialized instanceof UInt8, 'Should be instance of UInt8');
       assert.strictEqual(
         deserialized.toString(),
@@ -70,7 +79,10 @@ test('Deserialize Spec', async (t) => {
     });
 
     await t.test('UInt32', () => {
-      const deserialized = deserializeProvable('UInt32', '4294967295');
+      const deserialized = deserializeProvable({
+        _type: 'UInt32',
+        value: '4294967295',
+      });
       assert(deserialized instanceof UInt32, 'Should be instance of UInt32');
       assert.strictEqual(
         deserialized.toString(),
@@ -80,10 +92,10 @@ test('Deserialize Spec', async (t) => {
     });
 
     await t.test('UInt64', () => {
-      const deserialized = deserializeProvable(
-        'UInt64',
-        '18446744073709551615'
-      );
+      const deserialized = deserializeProvable({
+        _type: 'UInt64',
+        value: '18446744073709551615',
+      });
       assert(deserialized instanceof UInt64, 'Should be instance of UInt64');
       assert.strictEqual(
         deserialized.toString(),
@@ -95,7 +107,10 @@ test('Deserialize Spec', async (t) => {
     await t.test('PublicKey', () => {
       const publicKeyBase58 =
         'B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg';
-      const deserialized = deserializeProvable('PublicKey', publicKeyBase58);
+      const deserialized = deserializeProvable({
+        _type: 'PublicKey',
+        value: publicKeyBase58,
+      });
       assert(
         deserialized instanceof PublicKey,
         'Should be instance of PublicKey'
@@ -118,10 +133,7 @@ test('Deserialize Spec', async (t) => {
       const serializedSignature = serializeProvable(signature);
 
       // Deserialize the signature
-      const deserialized = deserializeProvable(
-        serializedSignature._type,
-        serializedSignature.value
-      );
+      const deserialized = deserializeProvable(serializedSignature);
 
       assert(
         deserialized instanceof Signature,
@@ -143,7 +155,7 @@ test('Deserialize Spec', async (t) => {
 
     await t.test('Invalid type', () => {
       assert.throws(
-        () => deserializeProvable('InvalidType' as any, '42'),
+        () => deserializeProvable({ _type: 'InvalidType' as any, value: '42' }),
         { message: 'Unsupported provable type: InvalidType' },
         'Should throw for invalid type'
       );

--- a/tests/serialize.test.ts
+++ b/tests/serialize.test.ts
@@ -445,7 +445,7 @@ test('serializeInput', async (t) => {
 
     const expected = {
       type: 'credential',
-      id: 'none',
+      credentialType: 'unsigned',
       witness: { _type: 'Undefined' },
       data: { _type: 'Field' },
     };
@@ -460,7 +460,7 @@ test('serializeInput', async (t) => {
 
     const expected = {
       type: 'credential',
-      id: 'signature-native',
+      credentialType: 'simple',
       witness: {
         type: { type: 'Constant', value: 'simple' },
         issuer: { _type: 'PublicKey' },
@@ -489,7 +489,7 @@ test('serializeInput', async (t) => {
 
     const expected = {
       type: 'credential',
-      id: 'none',
+      credentialType: 'unsigned',
       witness: { _type: 'Undefined' },
       data: {
         personal: {
@@ -532,7 +532,7 @@ test('convertSpecToSerializable', async (t) => {
       inputs: {
         age: {
           type: 'credential',
-          id: 'none',
+          credentialType: 'unsigned',
           witness: { _type: 'Undefined' },
           data: { _type: 'Field' },
         },
@@ -600,7 +600,7 @@ test('convertSpecToSerializable', async (t) => {
       inputs: {
         signedData: {
           type: 'credential',
-          id: 'signature-native',
+          credentialType: 'simple',
           witness: {
             type: { type: 'Constant', value: 'simple' },
             issuer: { _type: 'PublicKey' },
@@ -669,13 +669,13 @@ test('convertSpecToSerializable', async (t) => {
       inputs: {
         field1: {
           type: 'credential',
-          id: 'none',
+          credentialType: 'unsigned',
           witness: { _type: 'Undefined' },
           data: { _type: 'Field' },
         },
         field2: {
           type: 'credential',
-          id: 'none',
+          credentialType: 'unsigned',
           witness: { _type: 'Undefined' },
           data: { _type: 'Field' },
         },

--- a/tests/serialize.test.ts
+++ b/tests/serialize.test.ts
@@ -334,7 +334,8 @@ test('Serialize Nodes', async (t) => {
 
     const expected = {
       type: 'hash',
-      inner: { type: 'constant', data: { _type: 'Field', value: '123' } },
+      inputs: [{ type: 'constant', data: { _type: 'Field', value: '123' } }],
+      prefix: null,
     };
 
     assert.deepStrictEqual(serialized, expected);

--- a/tests/serialize.test.ts
+++ b/tests/serialize.test.ts
@@ -432,7 +432,7 @@ test('serializeInput', async (t) => {
     const serialized = serializeInput(input);
 
     const expected = {
-      type: 'public',
+      type: 'claim',
       data: { _type: 'Field' },
     };
 
@@ -537,7 +537,7 @@ test('convertSpecToSerializable', async (t) => {
           witness: { _type: 'Undefined' },
           data: { _type: 'Field' },
         },
-        isAdmin: { type: 'public', data: { _type: 'Bool' } },
+        isAdmin: { type: 'claim', data: { _type: 'Bool' } },
         maxAge: { type: 'constant', data: { _type: 'Field' }, value: '100' },
       },
       logic: {
@@ -768,7 +768,7 @@ test('Serialize and deserialize spec with hash', async (t) => {
   await t.test('should detect tampering', async () => {
     const tampered = JSON.parse(serialized);
     const tamperedSpec = JSON.parse(tampered.spec);
-    tamperedSpec.inputs.age.type = 'public';
+    tamperedSpec.inputs.age.type = 'claim';
     tampered.spec = JSON.stringify(tamperedSpec);
     const tamperedString = JSON.stringify(tampered);
     assert(
@@ -782,7 +782,7 @@ test('Serialize and deserialize spec with hash', async (t) => {
     async () => {
       const tampered = JSON.parse(serialized);
       const tamperedSpec = JSON.parse(tampered.spec);
-      tamperedSpec.inputs.age.type = 'public';
+      tamperedSpec.inputs.age.type = 'claim';
       tampered.spec = JSON.stringify(tamperedSpec);
       const tamperedString = JSON.stringify(tampered);
 

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -1,7 +1,7 @@
 import { Field, PrivateKey } from 'o1js';
 import {
   type Credential,
-  type CredentialType,
+  type CredentialSpec,
   signCredentials,
 } from '../src/credential.ts';
 
@@ -13,7 +13,7 @@ const { publicKey: issuer, privateKey: issuerKey } = PrivateKey.randomKeypair();
 function createOwnerSignature<Witness, Data>(
   context: Field,
   ...credentials: [
-    CredentialType<any, Witness, Data>,
+    CredentialSpec<any, Witness, Data>,
     { credential: Credential<Data>; witness: Witness }
   ][]
 ) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["./src", "./tests"],
+  "include": ["./src", "./tests", "./examples"],
   "compilerOptions": {
     "outDir": "./build",
     "rootDir": ".",


### PR DESCRIPTION
this adds an e2e example (featuring a "nullifier" = hash of data with enough entropy + app id), and several changes required to make the example feel natural and complete

closes #48
closes #38 

* `validateCredential()` for when importing a credential into the wallet
* `Credential.toJSON` / `fromJSON` to serialize credentials
* credentials now have a method to verify them outside a circuit (this is different than inside for proofs: it's not a recursive proof but full proof verification)
* add new `Operation` node: `equalsOneOf()` to check that one value is contained in a (smallish) list
  * "smallish" because it doesn't use a Merkle tree but just checks for equality with each value in the list
* enable creating and serializing array types (probably will replace later with array types from https://github.com/zksecurity/mina-credentials/pull/25)
* `Operation.hash` now takes multiple values, and handles composite types, and (optionally) can take a hash prefix
* added `/examples` folder and run its contents in CI