### PR TITLE
Polish APIs for specifying context

### DIFF
--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -76,7 +76,7 @@ console.log('✅ VERIFIER: created presentation request:', requestJson);
 // WALLET: deserialize request and create presentation
 
 console.time('compile');
-let deserialized = PresentationRequest.fromJSON<typeof request>(requestJson);
+let deserialized = PresentationRequest.fromJSON('no-context', requestJson);
 let compiled = await Presentation.compile(deserialized);
 console.timeEnd('compile');
 
@@ -84,6 +84,7 @@ console.time('create');
 let presentation = await Presentation.create(ownerKey, {
   request: compiled,
   credentials: [storedCredential],
+  walletContext: undefined,
 });
 console.timeEnd('create');
 // TODO: to send the presentation back we need to serialize it as well

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -64,10 +64,14 @@ const spec = Spec(
 
 const targetNationalities = ['United States of America', 'Canada', 'Mexico'];
 
-let request = PresentationRequest.noContext(spec, {
-  targetNationalities: targetNationalities.map((s) => Bytes32.fromString(s)),
-  appId: Bytes32.fromString('my-app-id:123'),
-});
+let request = await PresentationRequest.https(
+  spec,
+  {
+    targetNationalities: targetNationalities.map((s) => Bytes32.fromString(s)),
+    appId: Bytes32.fromString('my-app-id:123'),
+  },
+  { action: 'my-app-id:123:authenticate' }
+);
 let requestJson = PresentationRequest.toJSON(request);
 
 console.log('✅ VERIFIER: created presentation request:', requestJson);
@@ -76,7 +80,7 @@ console.log('✅ VERIFIER: created presentation request:', requestJson);
 // WALLET: deserialize request and create presentation
 
 console.time('compile');
-let deserialized = PresentationRequest.fromJSON('no-context', requestJson);
+let deserialized = PresentationRequest.fromJSON('https', requestJson);
 let compiled = await Presentation.compile(deserialized);
 console.timeEnd('compile');
 
@@ -84,7 +88,7 @@ console.time('create');
 let presentation = await Presentation.create(ownerKey, {
   request: compiled,
   credentials: [storedCredential],
-  context: undefined,
+  context: { verifierIdentity: 'my-app.xyz' },
 });
 console.timeEnd('create');
 // TODO: to send the presentation back we need to serialize it as well

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -7,6 +7,7 @@ import {
   Presentation,
   PresentationRequest,
   assert,
+  type InferSchema,
 } from '../src/index.ts';
 import { issuerKey, owner, ownerKey } from '../tests/test-utils.ts';
 import { validateCredential } from '../src/credential-index.ts';
@@ -16,12 +17,12 @@ import { array } from '../src/o1js-missing.ts';
 const Bytes32 = Bytes(32);
 const Bytes16 = Bytes(16); // 16 bytes = 128 bits = enough entropy
 
-const Data = { nationality: Bytes32, id: Bytes16 };
+const Schema = { nationality: Bytes32, id: Bytes16 };
 
 // ---------------------------------------------
 // ISSUER: issue a signed credential to the owner
 
-let data = {
+let data: InferSchema<typeof Schema> = {
   nationality: Bytes32.fromString('United States of America'),
   id: Bytes16.random(),
 };
@@ -44,7 +45,7 @@ console.log('✅ WALLET: imported and validated credential');
 
 const spec = Spec(
   {
-    signedData: Credential.Simple(Data), // schema needed here!
+    signedData: Credential.Simple(Schema), // schema needed here!
     targetNationalities: Claim(array(Bytes32, 3)), // TODO would make more sense as dynamic array
     appId: Claim(Bytes32),
   },

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -57,7 +57,7 @@ const spec = Spec(
       targetNationalities
     ),
     // we expose a unique hash of the credential data, as nullifier
-    data: Operation.record({
+    ouputClaim: Operation.record({
       nullifier: Operation.hash(signedData, appId),
     }),
   })

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -84,7 +84,7 @@ console.time('create');
 let presentation = await Presentation.create(ownerKey, {
   request: compiled,
   credentials: [storedCredential],
-  walletContext: undefined,
+  context: undefined,
 });
 console.timeEnd('create');
 // TODO: to send the presentation back we need to serialize it as well

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -65,7 +65,7 @@ const spec = Spec(
 
 const targetNationalities = ['United States of America', 'Canada', 'Mexico'];
 
-let request = await PresentationRequest.https(
+let request = PresentationRequest.https(
   spec,
   {
     targetNationalities: targetNationalities.map((s) => Bytes32.fromString(s)),

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,8 +12,6 @@ type BaseContextInput = {
   presentationCircuitVKHash: Field;
   clientNonce: Field;
   serverNonce: Field;
-  // TODO: change after Gregor's PR
-  // add a separate output claim or alternatively hash them together to get one Field element
   claims: Field;
 };
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,8 +1,6 @@
 import { Field, PublicKey, Bytes, Poseidon, Hash } from 'o1js';
 import { prefixes } from './constants.ts';
 
-export type { Context as ContextInput };
-
 export { computeContext, generateContext };
 
 type ContextType = 'zk-app' | 'https';

--- a/src/deserialize-spec.ts
+++ b/src/deserialize-spec.ts
@@ -23,7 +23,7 @@ import {
   supportedTypes,
   type O1jsTypeName,
   type SerializedType,
-  type SerializedValue,
+  type SerializedContext,
 } from './serialize-spec.ts';
 import { type CredentialType } from './credential.ts';
 import { Credential } from './credential-index.ts';
@@ -42,30 +42,14 @@ export {
   convertSpecFromSerializable,
 };
 
-function deserializeInputContext(
-  context: null | {
-    type: string;
-    vkHash: SerializedValue;
-    claims: SerializedValue;
-    action: SerializedValue | string;
-    serverNonce: SerializedValue;
-  }
-) {
+function deserializeInputContext(context: null | SerializedContext) {
   if (context === null) return undefined;
   return {
-    type: context.type as 'zk-app' | 'https',
-    vkHash: deserializeProvable({
-      _type: 'Field',
-      value: context.vkHash.value,
-    }),
-    claims: deserializeProvable(context.claims),
+    type: context.type,
     action:
       context.type === 'zk-app'
-        ? deserializeProvable({
-            _type: 'Field',
-            value: (context.action as { _type: string; value: string }).value,
-          })
-        : (context.action as string),
+        ? deserializeProvable({ _type: 'Field', value: context.action.value })
+        : context.action,
     serverNonce: deserializeProvable({
       _type: 'Field',
       value: context.serverNonce.value,

--- a/src/deserialize-spec.ts
+++ b/src/deserialize-spec.ts
@@ -45,7 +45,7 @@ export {
 function deserializeInputContext(
   context: null | {
     type: string;
-    presentationCircuitVKHash: SerializedValue;
+    vkHash: SerializedValue;
     claims: SerializedValue;
     action: SerializedValue | string;
     serverNonce: SerializedValue;
@@ -54,9 +54,9 @@ function deserializeInputContext(
   if (context === null) return undefined;
   return {
     type: context.type as 'zk-app' | 'https',
-    presentationCircuitVKHash: deserializeProvable({
+    vkHash: deserializeProvable({
       _type: 'Field',
-      value: context.presentationCircuitVKHash.value,
+      value: context.vkHash.value,
     }),
     claims: deserializeProvable(context.claims),
     action:

--- a/src/deserialize-spec.ts
+++ b/src/deserialize-spec.ts
@@ -88,7 +88,7 @@ function convertSpecFromSerializable(parsedSpec: any): Spec {
     inputs,
     logic: {
       assert: deserializeNode(inputs, parsedSpec.logic.assert),
-      data: deserializeNode(inputs, parsedSpec.logic.data),
+      ouputClaim: deserializeNode(inputs, parsedSpec.logic.data),
     },
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,5 @@ export { Spec, Operation, Claim, Constant } from './program-spec.ts';
 export { Credential } from './credential-index.ts';
 export { Presentation, PresentationRequest } from './presentation.ts';
 export { assert } from './util.ts';
+
+export type { InferProvable as InferSchema } from 'o1js';

--- a/src/presentation.ts
+++ b/src/presentation.ts
@@ -84,7 +84,7 @@ type PresentationRequest<
 };
 
 const PresentationRequest = {
-  async https<Output, Inputs extends Record<string, Input>>(
+  https<Output, Inputs extends Record<string, Input>>(
     spec: Spec<Output, Inputs>,
     claims: Claims<Inputs>,
     context: { action: string }
@@ -108,13 +108,10 @@ const PresentationRequest = {
     // generate random nonce on "the server"
     let serverNonce = Field.random();
 
-    // compile program to get the verification key
-    let program = createProgram(spec);
-
     return ZkAppRequest({
       spec,
       claims,
-      program,
+      program: createProgram(spec),
       inputContext: { ...context, type: 'zk-app', serverNonce },
     });
   },

--- a/src/presentation.ts
+++ b/src/presentation.ts
@@ -203,11 +203,11 @@ async function createPresentation<R extends PresentationRequest>(
   ownerKey: PrivateKey,
   {
     request,
-    walletContext,
+    context: walletContext,
     credentials,
   }: {
     request: R;
-    walletContext: WalletContext<R>;
+    context: WalletContext<R>;
     credentials: (StoredCredential & { key?: string })[];
   }
 ): Promise<Presentation<Output<R>, Inputs<R>>> {

--- a/src/presentation.ts
+++ b/src/presentation.ts
@@ -76,7 +76,7 @@ const PresentationRequest = {
       inputContext: {
         type: 'https',
         ...context,
-        presentationCircuitVKHash: verificationKey.hash,
+        vkHash: verificationKey.hash,
         serverNonce,
         claims: hashClaims(claims),
       },
@@ -102,7 +102,7 @@ const PresentationRequest = {
       inputContext: {
         ...context,
         type: 'zk-app',
-        presentationCircuitVKHash: verificationKey.hash,
+        vkHash: verificationKey.hash,
         serverNonce,
         claims: hashClaims(claims),
       },
@@ -305,7 +305,7 @@ type NoContextRequest<
 > = PresentationRequest<'no-context', Output, Inputs, undefined, undefined>;
 
 type BaseInputContext = {
-  presentationCircuitVKHash: Field;
+  vkHash: Field;
   serverNonce: Field;
   claims: Field;
 };

--- a/src/program-spec.ts
+++ b/src/program-spec.ts
@@ -75,7 +75,7 @@ function Spec<Output, Inputs extends Record<string, Input>>(
     [K in keyof Inputs]: Node<GetData<Inputs[K]>>;
   }) => {
     assert?: Node<Bool>;
-    data: Node<Output>;
+    ouputClaim: Node<Output>;
   }
 ): Spec<Output, Inputs>;
 
@@ -90,12 +90,12 @@ function Spec<Inputs extends Record<string, Input>>(
 ): Spec<undefined, Inputs>;
 
 // implementation
-function Spec<Data, Inputs extends Record<string, Input>>(
+function Spec<Output, Inputs extends Record<string, Input>>(
   inputs: Inputs,
   spec: (inputs: {
     [K in keyof Inputs]: Node<GetData<Inputs[K]>>;
-  }) => OutputNode<Data>
-): Spec<Data, Inputs> {
+  }) => OutputNode<Output>
+): Spec<Output, Inputs> {
   let rootNode = root(inputs);
   let inputNodes: {
     [K in keyof Inputs]: Node<GetData<Inputs[K]>>;
@@ -116,9 +116,10 @@ function Spec<Data, Inputs extends Record<string, Input>>(
   }
   let logic = spec(inputNodes);
   let assertNode = logic.assert ?? Node.constant(Bool(true));
-  let data: Node<Data> = logic.data ?? (Node.constant(undefined) as any);
+  let ouputClaim: Node<Output> =
+    logic.ouputClaim ?? (Node.constant(undefined) as any);
 
-  return { inputs, logic: { assert: assertNode, data } };
+  return { inputs, logic: { assert: assertNode, ouputClaim } };
 }
 
 const Operation = {
@@ -189,7 +190,7 @@ type Node<Data = any> =
 
 type OutputNode<Data = any> = {
   assert?: Node<Bool>;
-  data?: Node<Data>;
+  ouputClaim?: Node<Data>;
 };
 
 const Node = {
@@ -624,7 +625,7 @@ function privateInputTypes({ inputs }: Spec): NestedProvableFor<{
 
 function publicOutputType(spec: Spec): ProvablePure<any> {
   let root = dataInputTypes(spec);
-  let outputTypeNested = Node.evalType(root, spec.logic.data);
+  let outputTypeNested = Node.evalType(root, spec.logic.ouputClaim);
   let outputType = NestedProvable.get(outputTypeNested);
   assertPure(outputType);
   return outputType;

--- a/src/program.ts
+++ b/src/program.ts
@@ -87,7 +87,7 @@ function createProgram<S extends Spec>(
             credentialOutputs
           );
           let assertion = Node.eval(root, spec.logic.assert);
-          let output = Node.eval(root, spec.logic.data);
+          let output = Node.eval(root, spec.logic.ouputClaim);
           assertion.assertTrue('Program assertion failed!');
           return { publicOutput: output };
         },

--- a/src/serialize-spec.ts
+++ b/src/serialize-spec.ts
@@ -217,12 +217,11 @@ function serializeNode(node: Node): object {
   }
 }
 
-function serializeInputContext(context: {
-  type: 'zk-app' | 'https';
-  presentationCircuitVKHash: Field;
-  action: Field | string;
-  serverNonce: Field;
-}): {
+function serializeInputContext(
+  context:
+    | ({ type: 'zk-app' } & ZkAppInputContext)
+    | ({ type: 'https' } & HttpsInputContext)
+): {
   type: string;
   presentationCircuitVKHash: ReturnType<typeof serializeProvable>;
   action: ReturnType<typeof serializeProvable> | string;
@@ -238,17 +237,12 @@ function serializeInputContext(context: {
 
   switch (context.type) {
     case 'zk-app':
-      return {
-        ...serializedBase,
-        action: serializeProvable(context.action as Field),
-      };
+      let action = serializeProvable(context.action);
+      return { ...serializedBase, action };
     case 'https':
-      return {
-        ...serializedBase,
-        action: context.action as string,
-      };
+      return { ...serializedBase, action: context.action };
     default:
-      throw Error(`Unsupported context type: ${context.type}`);
+      throw Error(`Unsupported context type: ${(context as any).type}`);
   }
 }
 

--- a/src/serialize-spec.ts
+++ b/src/serialize-spec.ts
@@ -202,7 +202,7 @@ function serializeInputContext(
     | ({ type: 'https' } & HttpsInputContext)
 ): null | {
   type: string;
-  presentationCircuitVKHash: SerializedValue;
+  vkHash: SerializedValue;
   claims: SerializedValue;
   action: SerializedValue | string;
   serverNonce: SerializedValue;
@@ -210,9 +210,7 @@ function serializeInputContext(
   if (context === undefined) return null;
   const serializedBase = {
     type: context.type,
-    presentationCircuitVKHash: serializeProvable(
-      context.presentationCircuitVKHash
-    ),
+    vkHash: serializeProvable(context.vkHash),
     claims: serializeProvable(context.claims),
     serverNonce: serializeProvable(context.serverNonce),
   };

--- a/src/serialize-spec.ts
+++ b/src/serialize-spec.ts
@@ -70,7 +70,7 @@ function convertSpecToSerializable(spec: Spec): Record<string, any> {
     inputs: serializeInputs(spec.inputs),
     logic: {
       assert: serializeNode(spec.logic.assert),
-      data: serializeNode(spec.logic.data),
+      data: serializeNode(spec.logic.ouputClaim),
     },
   };
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,8 +1,24 @@
-export { assert, assertHasProperty, hasProperty, assertIsObject, zip };
+export {
+  assert,
+  assertDefined,
+  assertHasProperty,
+  hasProperty,
+  assertIsObject,
+  zip,
+};
 
 function assert(condition: boolean, message?: string): asserts condition {
   if (!condition) {
     throw Error(message ?? 'Assertion failed');
+  }
+}
+
+function assertDefined<T>(
+  input: T | undefined,
+  message?: string
+): asserts input is T {
+  if (input === undefined) {
+    throw Error(message ?? 'Input is undefined');
   }
 }
 

--- a/tests/deserialize.test.ts
+++ b/tests/deserialize.test.ts
@@ -37,7 +37,7 @@ import {
   PresentationRequest,
   ZkAppRequest,
 } from '../src/presentation.ts';
-import { zkAppVerifierIdentity } from './test-utils.ts';
+import { zkAppAddress } from './test-utils.ts';
 import { computeContext, generateContext } from '../src/context.ts';
 
 test('Deserialize Spec', async (t) => {
@@ -824,9 +824,10 @@ test('deserializePresentationRequest with context', async (t) => {
     assert(context, 'Context should exist');
     assert.deepStrictEqual(context.presentationCircuitVKHash, Field(123));
     assert.deepStrictEqual(context.action, Field(123));
+    assert.deepStrictEqual(context.serverNonce, Field(789));
 
     const walletContext = {
-      verifierIdentity: zkAppVerifierIdentity,
+      verifierIdentity: zkAppAddress,
       clientNonce: Field(999),
     };
 
@@ -876,6 +877,7 @@ test('deserializePresentationRequest with context', async (t) => {
     assert(context, 'Context should exist');
     assert.deepStrictEqual(context.presentationCircuitVKHash, Field(123));
     assert.strictEqual(context.action, 'POST /api/verify');
+    assert.deepStrictEqual(context.serverNonce, Field(789));
 
     const walletContext = {
       verifierIdentity: serverUrl,

--- a/tests/deserialize.test.ts
+++ b/tests/deserialize.test.ts
@@ -801,7 +801,7 @@ test('deserializePresentationRequest with context', async (t) => {
       claims: { targetAge: Field(18) },
       inputContext: {
         type: 'zk-app',
-        presentationCircuitVKHash: Field(123),
+        vkHash: Field(123),
         action: Field(123), // Mock method ID + args hash
         claims: Field(456),
         serverNonce: Field(789),
@@ -822,7 +822,7 @@ test('deserializePresentationRequest with context', async (t) => {
 
     const context = deserialized.inputContext;
     assert(context, 'Context should exist');
-    assert.deepStrictEqual(context.presentationCircuitVKHash, Field(123));
+    assert.deepStrictEqual(context.vkHash, Field(123));
     assert.deepStrictEqual(context.action, Field(123));
     assert.deepStrictEqual(context.serverNonce, Field(789));
 
@@ -854,7 +854,7 @@ test('deserializePresentationRequest with context', async (t) => {
       claims: { targetAge: Field(18) },
       inputContext: {
         type: 'https',
-        presentationCircuitVKHash: Field(123),
+        vkHash: Field(123),
         action: 'POST /api/verify',
         claims: Field(456),
         serverNonce: Field(789),
@@ -875,7 +875,7 @@ test('deserializePresentationRequest with context', async (t) => {
 
     const context = deserialized.inputContext;
     assert(context, 'Context should exist');
-    assert.deepStrictEqual(context.presentationCircuitVKHash, Field(123));
+    assert.deepStrictEqual(context.vkHash, Field(123));
     assert.strictEqual(context.action, 'POST /api/verify');
     assert.deepStrictEqual(context.serverNonce, Field(789));
 

--- a/tests/deserialize.test.ts
+++ b/tests/deserialize.test.ts
@@ -35,6 +35,7 @@ import { withOwner } from '../src/credential.ts';
 import {
   HttpsRequest,
   PresentationRequest,
+  type WalletDerivedContext,
   ZkAppRequest,
 } from '../src/presentation.ts';
 import { zkAppAddress } from './test-utils.ts';
@@ -801,9 +802,7 @@ test('deserializePresentationRequest with context', async (t) => {
       claims: { targetAge: Field(18) },
       inputContext: {
         type: 'zk-app',
-        vkHash: Field(123),
         action: Field(123), // Mock method ID + args hash
-        claims: Field(456),
         serverNonce: Field(789),
       },
     });
@@ -822,25 +821,27 @@ test('deserializePresentationRequest with context', async (t) => {
 
     const context = deserialized.inputContext;
     assert(context, 'Context should exist');
-    assert.deepStrictEqual(context.vkHash, Field(123));
     assert.deepStrictEqual(context.action, Field(123));
     assert.deepStrictEqual(context.serverNonce, Field(789));
 
-    const walletContext = {
-      verifierIdentity: zkAppAddress,
+    let derivedContext: WalletDerivedContext = {
       clientNonce: Field(999),
+      vkHash: Field(123),
+      claims: Field(456),
     };
 
     const originalContext = generateContext(
       computeContext({
         ...originalRequest.inputContext,
-        ...walletContext,
+        verifierIdentity: zkAppAddress,
+        ...derivedContext,
       })
     );
     const deserializedContext = generateContext(
       computeContext({
-        ...deserialized.inputContext,
-        ...walletContext,
+        ...originalRequest.inputContext,
+        verifierIdentity: zkAppAddress,
+        ...derivedContext,
       })
     );
     assert.deepStrictEqual(deserializedContext, originalContext);
@@ -854,9 +855,7 @@ test('deserializePresentationRequest with context', async (t) => {
       claims: { targetAge: Field(18) },
       inputContext: {
         type: 'https',
-        vkHash: Field(123),
         action: 'POST /api/verify',
-        claims: Field(456),
         serverNonce: Field(789),
       },
     });
@@ -875,25 +874,27 @@ test('deserializePresentationRequest with context', async (t) => {
 
     const context = deserialized.inputContext;
     assert(context, 'Context should exist');
-    assert.deepStrictEqual(context.vkHash, Field(123));
     assert.strictEqual(context.action, 'POST /api/verify');
     assert.deepStrictEqual(context.serverNonce, Field(789));
 
-    const walletContext = {
-      verifierIdentity: serverUrl,
+    let derivedContext: WalletDerivedContext = {
       clientNonce: Field(999),
+      vkHash: Field(123),
+      claims: Field(456),
     };
 
     const originalContext = generateContext(
       computeContext({
         ...originalRequest.inputContext,
-        ...walletContext,
+        verifierIdentity: serverUrl,
+        ...derivedContext,
       })
     );
     const deserializedContext = generateContext(
       computeContext({
-        ...deserialized.inputContext,
-        ...walletContext,
+        ...originalRequest.inputContext,
+        verifierIdentity: serverUrl,
+        ...derivedContext,
       })
     );
     assert.deepStrictEqual(deserializedContext, originalContext);

--- a/tests/deserialize.test.ts
+++ b/tests/deserialize.test.ts
@@ -587,7 +587,7 @@ test('deserializeSpec', async (t) => {
         },
         ({ age, isAdmin, maxAge }) => ({
           assert: Operation.and(Operation.lessThan(age, maxAge), isAdmin),
-          data: age,
+          ouputClaim: age,
         })
       );
 
@@ -625,7 +625,7 @@ test('deserializeSpec', async (t) => {
             Operation.property(signedData, 'field'),
             zeroField
           ),
-          data: signedData,
+          ouputClaim: signedData,
         })
       );
 
@@ -671,7 +671,7 @@ test('deserializeSpec', async (t) => {
             Operation.lessThan(field1, field2),
             Operation.lessThanEq(field2, threshold)
           ),
-          data: Operation.equals(field1, field2),
+          ouputClaim: Operation.equals(field1, field2),
         })
       );
 
@@ -703,7 +703,7 @@ test('deserializeSpec', async (t) => {
             Operation.property(signedData, 'age'),
             targetAge
           ),
-          data: Operation.record({
+          ouputClaim: Operation.record({
             owner: Operation.owner,
             issuer: Operation.issuer(signedData),
             age: Operation.property(signedData, 'age'),
@@ -736,7 +736,7 @@ test('deserializeSpec', async (t) => {
         },
         ({ provedData, zeroField }) => ({
           assert: Operation.equals(provedData, zeroField),
-          data: provedData,
+          ouputClaim: provedData,
         })
       );
 
@@ -791,7 +791,7 @@ test('deserializePresentationRequest with context', async (t) => {
         Operation.equals(Operation.property(signedData, 'age'), targetAge),
         Operation.equals(Operation.property(signedData, 'name'), targetName)
       ),
-      data: Operation.property(signedData, 'age'),
+      ouputClaim: Operation.property(signedData, 'age'),
     })
   );
 

--- a/tests/presentation-with-proof.test.ts
+++ b/tests/presentation-with-proof.test.ts
@@ -11,9 +11,6 @@ import { signCredentials } from '../src/credential.ts';
 const Bytes32 = Bytes(32);
 const InputData = { age: Field, name: Bytes32 };
 
-// TODO
-let context = Field(0);
-
 // simple spec to create a proof credential that's used recursively
 // TODO create a more interesting input proof
 const inputProofSpec = Spec(
@@ -125,8 +122,9 @@ await describe('program with proof credential', async () => {
 
   await test('run program with invalid signature', async () => {
     // changing the context makes the signature invalid
-    let invalidContext = context.add(1);
-    let ownerSignature = signCredentials(ownerKey, invalidContext, {
+    let actualContext = Field(0);
+    let invalidContext = Field(1);
+    let ownerSignature = signCredentials(ownerKey, actualContext, {
       ...provedData,
       credentialType: Recursive,
     });
@@ -134,7 +132,7 @@ await describe('program with proof credential', async () => {
     await assert.rejects(
       async () =>
         await request.program.run({
-          context,
+          context: invalidContext,
           ownerSignature,
           credentials: { provedData },
           claims: { targetAge: Field(18) },

--- a/tests/presentation-with-proof.test.ts
+++ b/tests/presentation-with-proof.test.ts
@@ -84,7 +84,7 @@ await describe('program with proof credential', async () => {
     let { proof } = await Presentation.create(ownerKey, {
       request,
       credentials: [provedData],
-      walletContext: undefined,
+      context: undefined,
     });
 
     assert(proof, 'Proof should be generated');
@@ -109,7 +109,7 @@ await describe('program with proof credential', async () => {
         await Presentation.create(ownerKey, {
           request,
           credentials: [provedData],
-          walletContext: undefined,
+          context: undefined,
         }),
       (err) => {
         assert(err instanceof Error, 'Should throw an Error');

--- a/tests/presentation-with-proof.test.ts
+++ b/tests/presentation-with-proof.test.ts
@@ -16,7 +16,7 @@ const InputData = { age: Field, name: Bytes32 };
 const inputProofSpec = Spec(
   { inputOwner: Claim(PublicKey), data: Claim(InputData) },
   ({ inputOwner, data }) => ({
-    data: Operation.record({ owner: inputOwner, data }),
+    ouputClaim: Operation.record({ owner: inputOwner, data }),
   })
 );
 
@@ -44,7 +44,7 @@ const spec = Spec(
       Operation.equals(Operation.property(provedData, 'age'), targetAge),
       Operation.equals(Operation.property(provedData, 'name'), targetName)
     ),
-    data: Operation.property(provedData, 'age'),
+    ouputClaim: Operation.property(provedData, 'age'),
   })
 );
 let requestInitial = PresentationRequest.noContext(spec, {

--- a/tests/presentation-with-proof.test.ts
+++ b/tests/presentation-with-proof.test.ts
@@ -56,7 +56,10 @@ let requestInitial = PresentationRequest.noContext(spec, {
 let json = PresentationRequest.toJSON(requestInitial);
 
 // wallet: deserialize and compile request
-let deserialized = PresentationRequest.fromJSON<typeof requestInitial>(json);
+let deserialized = PresentationRequest.fromJSON<typeof requestInitial>(
+  'no-context',
+  json
+);
 let request = await Presentation.compile(deserialized);
 
 await describe('program with proof credential', async () => {
@@ -81,6 +84,7 @@ await describe('program with proof credential', async () => {
     let { proof } = await Presentation.create(ownerKey, {
       request,
       credentials: [provedData],
+      walletContext: undefined,
     });
 
     assert(proof, 'Proof should be generated');
@@ -105,6 +109,7 @@ await describe('program with proof credential', async () => {
         await Presentation.create(ownerKey, {
           request,
           credentials: [provedData],
+          walletContext: undefined,
         }),
       (err) => {
         assert(err instanceof Error, 'Should throw an Error');

--- a/tests/presentation.test.ts
+++ b/tests/presentation.test.ts
@@ -57,7 +57,7 @@ test('program with simple spec and signature credential', async (t) => {
     let { proof } = await Presentation.create(ownerKey, {
       request,
       credentials: [signedData],
-      walletContext: undefined,
+      context: undefined,
     });
 
     assert(proof, 'Proof should be generated');
@@ -83,7 +83,7 @@ test('program with simple spec and signature credential', async (t) => {
         await Presentation.create(ownerKey, {
           request,
           credentials: [signedData],
-          walletContext: undefined,
+          context: undefined,
         }),
       (err) => {
         assert(err instanceof Error, 'Should throw an Error');
@@ -110,7 +110,7 @@ test('program with simple spec and signature credential', async (t) => {
         await Presentation.create(ownerKey, {
           request,
           credentials: [signedData],
-          walletContext: undefined,
+          context: undefined,
         }),
       (err) => {
         assert(err instanceof Error, 'Should throw an Error');
@@ -163,7 +163,7 @@ test('program with owner and issuer operations', async (t) => {
     let { proof } = await Presentation.create(ownerKey, {
       request,
       credentials: [signedData],
-      walletContext: undefined,
+      context: undefined,
     });
 
     assert(proof, 'Proof should be generated');
@@ -208,7 +208,7 @@ test('presentation with context binding', async (t) => {
 
     let { proof } = await Presentation.create(ownerKey, {
       request,
-      walletContext: { verifierIdentity: zkAppVerifierIdentity },
+      context: { verifierIdentity: zkAppVerifierIdentity },
       credentials: [signedData],
     });
 
@@ -227,8 +227,8 @@ test('presentation with context binding', async (t) => {
 
     let { proof } = await Presentation.create(ownerKey, {
       request,
-      walletContext: { verifierIdentity: 'test.com' },
       credentials: [signedData],
+      context: { verifierIdentity: 'test.com' },
     });
 
     assert(proof, 'Proof should be generated');

--- a/tests/presentation.test.ts
+++ b/tests/presentation.test.ts
@@ -20,7 +20,7 @@ test('program with simple spec and signature credential', async (t) => {
         Operation.equals(Operation.property(signedData, 'age'), targetAge),
         Operation.equals(Operation.property(signedData, 'name'), targetName)
       ),
-      data: Operation.property(signedData, 'age'),
+      ouputClaim: Operation.property(signedData, 'age'),
     })
   );
 
@@ -136,7 +136,7 @@ test('program with owner and issuer operations', async (t) => {
         Operation.property(signedData, 'dummy'),
         expectedDummy
       ),
-      data: Operation.record({
+      ouputClaim: Operation.record({
         owner: Operation.owner,
         issuer: Operation.issuer(signedData),
         dummy: Operation.property(signedData, 'dummy'),
@@ -185,7 +185,7 @@ test('presentation with context binding', async (t) => {
         Operation.equals(Operation.property(signedData, 'age'), targetAge),
         Operation.equals(Operation.property(signedData, 'name'), targetName)
       ),
-      data: Operation.property(signedData, 'age'),
+      ouputClaim: Operation.property(signedData, 'age'),
     })
   );
   const data = { age: Field(18), name: Bytes32.fromString('Alice') };

--- a/tests/presentation.test.ts
+++ b/tests/presentation.test.ts
@@ -197,20 +197,13 @@ test('presentation with context binding', async (t) => {
   );
 
   await t.test('presentation with zk-app context', async () => {
-    const program = createProgram(spec);
-    const verificationKey = await program.compile();
-    const presentationCircuitVKHash = verificationKey.hash;
-
     const data = { age: Field(18), name: Bytes32.fromString('Alice') };
     const signedData = Credential.sign(issuerKey, { owner, data });
 
-    let request = PresentationRequest.zkApp(
+    let request = await PresentationRequest.zkApp(
       spec,
       { targetAge: Field(18) },
-      {
-        presentationCircuitVKHash,
-        action: Field(123), // Mock method ID + args hash
-      }
+      { action: Field(123) }
     );
 
     let { proof } = await Presentation.create(ownerKey, {
@@ -223,20 +216,13 @@ test('presentation with context binding', async (t) => {
   });
 
   await t.test('presentation with https context', async () => {
-    const program = createProgram(spec);
-    const verificationKey = await program.compile();
-    const presentationCircuitVKHash = verificationKey.hash;
-
     const data = { age: Field(18), name: Bytes32.fromString('Alice') };
     const signedData = Credential.sign(issuerKey, { owner, data });
 
-    let request = PresentationRequest.https(
+    let request = await PresentationRequest.https(
       spec,
       { targetAge: Field(18) },
-      {
-        presentationCircuitVKHash,
-        action: 'POST /api/verify',
-      }
+      { action: 'POST /api/verify' }
     );
 
     let { proof } = await Presentation.create(ownerKey, {

--- a/tests/program-spec.test.ts
+++ b/tests/program-spec.test.ts
@@ -32,7 +32,7 @@ test(' Spec and Node operations', async (t) => {
       },
       ({ data, targetAge }) => ({
         assert: Operation.equals(Operation.property(data, 'age'), targetAge),
-        data: Operation.property(data, 'age'),
+        ouputClaim: Operation.property(data, 'age'),
       })
     );
 
@@ -42,7 +42,7 @@ test(' Spec and Node operations', async (t) => {
     };
 
     const assertResult = Node.eval(root, spec.logic.assert);
-    const dataResult = Node.eval(root, spec.logic.data);
+    const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
     assert.strictEqual(assertResult.toBoolean(), true);
     assert.deepStrictEqual(dataResult, Field(25));
@@ -66,7 +66,7 @@ test(' Spec and Node operations', async (t) => {
           Operation.equals(Operation.property(data, 'age'), targetAge),
           Operation.equals(Operation.property(data, 'name'), targetName)
         ),
-        data: Operation.property(data, 'age'),
+        ouputClaim: Operation.property(data, 'age'),
       })
     );
 
@@ -77,7 +77,7 @@ test(' Spec and Node operations', async (t) => {
     };
 
     const assertResult = Node.eval(root, spec.logic.assert);
-    const dataResult = Node.eval(root, spec.logic.data);
+    const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
     assert.strictEqual(assertResult.toBoolean(), true);
     assert.deepStrictEqual(dataResult, Field(30));
@@ -96,7 +96,7 @@ test(' Spec and Node operations', async (t) => {
           Operation.equals(Operation.property(data, 'age'), targetAge),
           Operation.equals(Operation.property(data, 'name'), targetName)
         ),
-        data: Operation.property(data, 'age'),
+        ouputClaim: Operation.property(data, 'age'),
       })
     );
 
@@ -107,7 +107,7 @@ test(' Spec and Node operations', async (t) => {
     };
 
     const assertResult = Node.eval(root, spec.logic.assert);
-    const dataResult = Node.eval(root, spec.logic.data);
+    const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
     assert.strictEqual(assertResult.toBoolean(), true);
     assert.deepStrictEqual(dataResult, Field(30));
@@ -126,7 +126,7 @@ test(' Spec and Node operations', async (t) => {
           Operation.equals(Operation.property(data, 'age'), targetAge),
           Operation.equals(Operation.property(data, 'name'), targetName)
         ),
-        data: Operation.property(data, 'age'),
+        ouputClaim: Operation.property(data, 'age'),
       })
     );
 
@@ -137,7 +137,7 @@ test(' Spec and Node operations', async (t) => {
     };
 
     const assertResult = Node.eval(root, spec.logic.assert);
-    const dataResult = Node.eval(root, spec.logic.data);
+    const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
     assert.strictEqual(assertResult.toBoolean(), true);
     assert.deepStrictEqual(dataResult, Field(30));
@@ -158,7 +158,7 @@ test(' Spec and Node operations', async (t) => {
             Operation.equals(Operation.property(data, 'age'), targetAge),
             Operation.equals(Operation.property(data, 'name'), targetName)
           ),
-          data: Operation.property(data, 'age'),
+          ouputClaim: Operation.property(data, 'age'),
         })
       );
       const root: DataInputs<typeof spec.inputs> = {
@@ -168,7 +168,7 @@ test(' Spec and Node operations', async (t) => {
       };
 
       const assertResult = Node.eval(root, spec.logic.assert);
-      const dataResult = Node.eval(root, spec.logic.data);
+      const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
       assert.strictEqual(assertResult.toBoolean(), true);
       assert.deepStrictEqual(dataResult, Field(11));
@@ -190,7 +190,7 @@ test(' Spec and Node operations', async (t) => {
           ),
           Operation.equals(Operation.property(data, 'name'), targetName)
         ),
-        data: Operation.property(data, 'age'),
+        ouputClaim: Operation.property(data, 'age'),
       })
     );
 
@@ -201,7 +201,7 @@ test(' Spec and Node operations', async (t) => {
     };
 
     const assertResult = Node.eval(root, spec.logic.assert);
-    const dataResult = Node.eval(root, spec.logic.data);
+    const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
     assert.strictEqual(assertResult.toBoolean(), true);
     assert.deepStrictEqual(dataResult, Field(11));
@@ -219,7 +219,7 @@ test(' Spec and Node operations', async (t) => {
           Operation.hash(Operation.property(data, 'value')),
           expectedHash
         ),
-        data: Operation.property(data, 'value'),
+        ouputClaim: Operation.property(data, 'value'),
       })
     );
 
@@ -232,7 +232,7 @@ test(' Spec and Node operations', async (t) => {
     };
 
     const assertResult = Node.eval(root, spec.logic.assert);
-    const dataResult = Node.eval(root, spec.logic.data);
+    const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
     assert.strictEqual(assertResult.toBoolean(), true);
     assert.deepStrictEqual(dataResult, inputValue);
@@ -251,7 +251,7 @@ test(' Spec and Node operations', async (t) => {
           Operation.lessThan(targetAge, Operation.property(data, 'age')),
           Operation.equals(Operation.property(data, 'name'), targetName)
         ),
-        data: Operation.property(data, 'age'),
+        ouputClaim: Operation.property(data, 'age'),
       })
     );
 
@@ -262,7 +262,7 @@ test(' Spec and Node operations', async (t) => {
     };
 
     const assertResult = Node.eval(root, spec.logic.assert);
-    const dataResult = Node.eval(root, spec.logic.data);
+    const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
     assert.strictEqual(assertResult.toBoolean(), true);
     assert.deepStrictEqual(dataResult, Field(30));
@@ -281,7 +281,7 @@ test(' Spec and Node operations', async (t) => {
           Operation.lessThanEq(Operation.property(data, 'age'), targetAge),
           Operation.equals(Operation.property(data, 'name'), targetName)
         ),
-        data: Operation.property(data, 'age'),
+        ouputClaim: Operation.property(data, 'age'),
       })
     );
 
@@ -292,7 +292,7 @@ test(' Spec and Node operations', async (t) => {
     };
 
     const assertResult = Node.eval(root, spec.logic.assert);
-    const dataResult = Node.eval(root, spec.logic.data);
+    const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
     assert.strictEqual(assertResult.toBoolean(), true);
     assert.deepStrictEqual(dataResult, Field(30));
@@ -307,7 +307,7 @@ test(' Spec and Node operations', async (t) => {
       },
       ({ value1, value2, sum }) => ({
         assert: Operation.equals(Operation.add(value1, value2), sum),
-        data: Operation.add(value1, value2),
+        ouputClaim: Operation.add(value1, value2),
       })
     );
 
@@ -318,7 +318,7 @@ test(' Spec and Node operations', async (t) => {
     };
 
     const assertResult = Node.eval(root, spec.logic.assert);
-    const dataResult = Node.eval(root, spec.logic.data);
+    const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
     assert.strictEqual(assertResult.toBoolean(), true);
     assert.deepStrictEqual(dataResult, UInt64.from(2000000));
@@ -333,7 +333,7 @@ test(' Spec and Node operations', async (t) => {
       },
       ({ value1, value2, difference }) => ({
         assert: Operation.equals(Operation.sub(value1, value2), difference),
-        data: Operation.sub(value1, value2),
+        ouputClaim: Operation.sub(value1, value2),
       })
     );
 
@@ -344,7 +344,7 @@ test(' Spec and Node operations', async (t) => {
     };
 
     const assertResult = Node.eval(root, spec.logic.assert);
-    const dataResult = Node.eval(root, spec.logic.data);
+    const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
     assert.strictEqual(assertResult.toBoolean(), true);
     assert.deepStrictEqual(dataResult, UInt32.from(800));
@@ -359,7 +359,7 @@ test(' Spec and Node operations', async (t) => {
       },
       ({ value1, value2, product }) => ({
         assert: Operation.equals(Operation.mul(value1, value2), product),
-        data: Operation.mul(value1, value2),
+        ouputClaim: Operation.mul(value1, value2),
       })
     );
 
@@ -370,7 +370,7 @@ test(' Spec and Node operations', async (t) => {
     };
 
     const assertResult = Node.eval(root, spec.logic.assert);
-    const dataResult = Node.eval(root, spec.logic.data);
+    const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
     assert.strictEqual(assertResult.toBoolean(), true);
     assert.deepStrictEqual(dataResult, UInt64.from(2000000));
@@ -385,7 +385,7 @@ test(' Spec and Node operations', async (t) => {
       },
       ({ value1, value2, quotient }) => ({
         assert: Operation.equals(Operation.div(value1, value2), quotient),
-        data: Operation.div(value1, value2),
+        ouputClaim: Operation.div(value1, value2),
       })
     );
 
@@ -396,7 +396,7 @@ test(' Spec and Node operations', async (t) => {
     };
 
     const assertResult = Node.eval(root, spec.logic.assert);
-    const dataResult = Node.eval(root, spec.logic.data);
+    const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
     assert.strictEqual(assertResult.toBoolean(), true);
     assert.deepStrictEqual(dataResult, UInt64.from(1000));
@@ -412,7 +412,7 @@ test(' Spec and Node operations', async (t) => {
       },
       ({ data, threshold, zero }) => ({
         assert: Node.constant(Bool(true)),
-        data: Operation.ifThenElse(
+        ouputClaim: Operation.ifThenElse(
           Operation.lessThan(Operation.property(data, 'value'), threshold),
           zero,
           Operation.property(data, 'value')
@@ -427,7 +427,7 @@ test(' Spec and Node operations', async (t) => {
       zero: Field(0),
     };
 
-    const result1 = Node.eval(root1, spec.logic.data);
+    const result1 = Node.eval(root1, spec.logic.ouputClaim);
     assert.deepStrictEqual(result1, Field(0));
 
     // value >= threshold
@@ -437,7 +437,7 @@ test(' Spec and Node operations', async (t) => {
       zero: Field(0),
     };
 
-    const result2 = Node.eval(root2, spec.logic.data);
+    const result2 = Node.eval(root2, spec.logic.ouputClaim);
     assert.deepStrictEqual(result2, Field(15));
   });
 
@@ -458,7 +458,7 @@ test(' Spec and Node operations', async (t) => {
             Operation.lessThan(Operation.property(data, 'value'), highLimit)
           )
         ),
-        data: Operation.property(data, 'value'),
+        ouputClaim: Operation.property(data, 'value'),
       })
     );
 
@@ -525,7 +525,7 @@ test(' Spec and Node operations', async (t) => {
             Operation.equals(Operation.property(data, 'value'), highLimit)
           )
         ),
-        data: Operation.property(data, 'value'),
+        ouputClaim: Operation.property(data, 'value'),
       })
     );
 
@@ -581,7 +581,7 @@ test(' Spec and Node operations', async (t) => {
           input: Credential.Unsigned({ x: Field, y: Field }),
         },
         ({ input }) => ({
-          data: Operation.compute(
+          ouputClaim: Operation.compute(
             [Operation.property(input, 'x'), Operation.property(input, 'y')],
             Field,
             (x, y) => x.add(y)
@@ -593,7 +593,7 @@ test(' Spec and Node operations', async (t) => {
         input: cred({ x: Field(10), y: Field(5) }),
       };
 
-      const result = Node.eval(root, spec.logic.data);
+      const result = Node.eval(root, spec.logic.ouputClaim);
       assert.deepStrictEqual(result, Field(15));
     });
 
@@ -604,7 +604,7 @@ test(' Spec and Node operations', async (t) => {
           threshold: Claim(Field),
         },
         ({ value, threshold }) => ({
-          data: Operation.compute([value, threshold], Bool, (v, t) =>
+          ouputClaim: Operation.compute([value, threshold], Bool, (v, t) =>
             v.greaterThan(t)
           ),
         })
@@ -620,8 +620,8 @@ test(' Spec and Node operations', async (t) => {
         threshold: Field(10),
       };
 
-      const validResult = Node.eval(validRoot, spec.logic.data);
-      const invalidResult = Node.eval(invalidRoot, spec.logic.data);
+      const validResult = Node.eval(validRoot, spec.logic.ouputClaim);
+      const invalidResult = Node.eval(invalidRoot, spec.logic.ouputClaim);
 
       assert.strictEqual(validResult.toBoolean(), true);
       assert.strictEqual(invalidResult.toBoolean(), false);
@@ -662,7 +662,7 @@ test(' Spec and Node operations', async (t) => {
               Bool,
               (d, max) => d.lessThanOrEqual(max.mul(max))
             ),
-            data: distanceSquared,
+            ouputClaim: distanceSquared,
           };
         }
       );
@@ -680,7 +680,7 @@ test(' Spec and Node operations', async (t) => {
       };
 
       const assertResult = Node.eval(root, spec.logic.assert);
-      const dataResult = Node.eval(root, spec.logic.data);
+      const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
       assert.strictEqual(assertResult.toBoolean(), true);
       assert.deepStrictEqual(dataResult, Field(25));
@@ -705,7 +705,10 @@ test(' Spec and Node operations', async (t) => {
           ),
           Operation.equals(Operation.property(data, 'points'), targetPoints)
         ),
-        data: Operation.property(Operation.property(data, 'person'), 'name'),
+        ouputClaim: Operation.property(
+          Operation.property(data, 'person'),
+          'name'
+        ),
       })
     );
 
@@ -719,7 +722,7 @@ test(' Spec and Node operations', async (t) => {
     };
 
     const assertResult = Node.eval(root, spec.logic.assert);
-    const dataResult = Node.eval(root, spec.logic.data);
+    const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
     assert.strictEqual(assertResult.toBoolean(), true);
     assert.deepStrictEqual(dataResult, Bytes32.fromString('Bob'));
@@ -734,7 +737,7 @@ test(' Spec and Node operations', async (t) => {
       },
       ({ data, constAge }) => ({
         assert: Operation.equals(Operation.property(data, 'age'), constAge),
-        data: Operation.property(data, 'name'),
+        ouputClaim: Operation.property(data, 'name'),
       })
     );
 
@@ -744,7 +747,7 @@ test(' Spec and Node operations', async (t) => {
     };
 
     const assertResult = Node.eval(root, spec.logic.assert);
-    const dataResult = Node.eval(root, spec.logic.data);
+    const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
     assert.strictEqual(assertResult.toBoolean(), true);
     assert.deepStrictEqual(dataResult, Bytes32.fromString('Charlie'));
@@ -763,7 +766,7 @@ test(' Spec and Node operations', async (t) => {
           Operation.equals(Operation.property(signedData, 'age'), targetAge),
           Operation.equals(Operation.property(signedData, 'name'), targetName)
         ),
-        data: Operation.property(signedData, 'age'),
+        ouputClaim: Operation.property(signedData, 'age'),
       })
     );
 
@@ -804,7 +807,7 @@ test(' Spec and Node operations', async (t) => {
     });
 
     const assertResult = Node.eval(root, spec.logic.assert);
-    const dataResult = Node.eval(root, spec.logic.data);
+    const dataResult = Node.eval(root, spec.logic.ouputClaim);
 
     assert.strictEqual(assertResult.toBoolean(), true);
     assert.deepStrictEqual(dataResult, Field(30));

--- a/tests/serialize.test.ts
+++ b/tests/serialize.test.ts
@@ -845,8 +845,6 @@ test('serializeInputContext', async (t) => {
   await t.test('should serialize zk-app context', () => {
     const context = {
       type: 'zk-app' as const,
-      vkHash: Field(123),
-      claims: Field(111),
       action: Field(456),
       serverNonce: Field(789),
     };
@@ -855,8 +853,6 @@ test('serializeInputContext', async (t) => {
 
     assert.deepStrictEqual(serialized, {
       type: 'zk-app',
-      vkHash: { _type: 'Field', value: '123' },
-      claims: { _type: 'Field', value: '111' },
       action: { _type: 'Field', value: '456' },
       serverNonce: { _type: 'Field', value: '789' },
     });
@@ -871,8 +867,6 @@ test('serializeInputContext', async (t) => {
   await t.test('should serialize https context', () => {
     const context = {
       type: 'https' as const,
-      vkHash: Field(123),
-      claims: Field(111),
       action: 'POST /api/verify',
       serverNonce: Field(789),
     };
@@ -881,8 +875,6 @@ test('serializeInputContext', async (t) => {
 
     assert.deepStrictEqual(serialized, {
       type: 'https',
-      vkHash: { _type: 'Field', value: '123' },
-      claims: { _type: 'Field', value: '111' },
       action: 'POST /api/verify',
       serverNonce: { _type: 'Field', value: '789' },
     });

--- a/tests/serialize.test.ts
+++ b/tests/serialize.test.ts
@@ -527,7 +527,7 @@ test('convertSpecToSerializable', async (t) => {
       },
       ({ age, isAdmin, maxAge }) => ({
         assert: Operation.and(Operation.lessThan(age, maxAge), isAdmin),
-        data: age,
+        ouputClaim: age,
       })
     );
 
@@ -596,7 +596,7 @@ test('convertSpecToSerializable', async (t) => {
           Operation.property(signedData, 'field'),
           zeroField
         ),
-        data: signedData,
+        ouputClaim: signedData,
       })
     );
 
@@ -665,7 +665,7 @@ test('convertSpecToSerializable', async (t) => {
           Operation.lessThan(field1, field2),
           Operation.equals(field1, zeroField)
         ),
-        data: field2,
+        ouputClaim: field2,
       })
     );
 
@@ -752,7 +752,7 @@ test('Serialize and deserialize spec with hash', async (t) => {
     },
     ({ age, isAdmin, ageLimit }) => ({
       assert: Operation.and(Operation.lessThan(age, ageLimit), isAdmin),
-      data: age,
+      ouputClaim: age,
     })
   );
 
@@ -819,7 +819,7 @@ test('Serialize spec with owner and issuer nodes', async (t) => {
         Operation.property(signedData, 'age'),
         targetAge
       ),
-      data: Operation.record({
+      ouputClaim: Operation.record({
         owner: Operation.owner,
         issuer: Operation.issuer(signedData),
         age: Operation.property(signedData, 'age'),

--- a/tests/serialize.test.ts
+++ b/tests/serialize.test.ts
@@ -846,6 +846,7 @@ test('serializeInputContext', async (t) => {
     const context = {
       type: 'zk-app' as const,
       presentationCircuitVKHash: Field(123),
+      claims: Field(111),
       action: Field(456),
       serverNonce: Field(789),
     };
@@ -855,6 +856,7 @@ test('serializeInputContext', async (t) => {
     assert.deepStrictEqual(serialized, {
       type: 'zk-app',
       presentationCircuitVKHash: { _type: 'Field', value: '123' },
+      claims: { _type: 'Field', value: '111' },
       action: { _type: 'Field', value: '456' },
       serverNonce: { _type: 'Field', value: '789' },
     });
@@ -870,6 +872,7 @@ test('serializeInputContext', async (t) => {
     const context = {
       type: 'https' as const,
       presentationCircuitVKHash: Field(123),
+      claims: Field(111),
       action: 'POST /api/verify',
       serverNonce: Field(789),
     };
@@ -879,6 +882,7 @@ test('serializeInputContext', async (t) => {
     assert.deepStrictEqual(serialized, {
       type: 'https',
       presentationCircuitVKHash: { _type: 'Field', value: '123' },
+      claims: { _type: 'Field', value: '111' },
       action: 'POST /api/verify',
       serverNonce: { _type: 'Field', value: '789' },
     });

--- a/tests/serialize.test.ts
+++ b/tests/serialize.test.ts
@@ -845,7 +845,7 @@ test('serializeInputContext', async (t) => {
   await t.test('should serialize zk-app context', () => {
     const context = {
       type: 'zk-app' as const,
-      presentationCircuitVKHash: Field(123),
+      vkHash: Field(123),
       claims: Field(111),
       action: Field(456),
       serverNonce: Field(789),
@@ -855,7 +855,7 @@ test('serializeInputContext', async (t) => {
 
     assert.deepStrictEqual(serialized, {
       type: 'zk-app',
-      presentationCircuitVKHash: { _type: 'Field', value: '123' },
+      vkHash: { _type: 'Field', value: '123' },
       claims: { _type: 'Field', value: '111' },
       action: { _type: 'Field', value: '456' },
       serverNonce: { _type: 'Field', value: '789' },
@@ -871,7 +871,7 @@ test('serializeInputContext', async (t) => {
   await t.test('should serialize https context', () => {
     const context = {
       type: 'https' as const,
-      presentationCircuitVKHash: Field(123),
+      vkHash: Field(123),
       claims: Field(111),
       action: 'POST /api/verify',
       serverNonce: Field(789),
@@ -881,7 +881,7 @@ test('serializeInputContext', async (t) => {
 
     assert.deepStrictEqual(serialized, {
       type: 'https',
-      presentationCircuitVKHash: { _type: 'Field', value: '123' },
+      vkHash: { _type: 'Field', value: '123' },
       claims: { _type: 'Field', value: '111' },
       action: 'POST /api/verify',
       serverNonce: { _type: 'Field', value: '789' },

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -11,12 +11,12 @@ export {
   ownerKey,
   issuer,
   issuerKey,
-  zkAppVerifierIdentity,
+  zkAppAddress,
 };
 
 const { publicKey: owner, privateKey: ownerKey } = PrivateKey.randomKeypair();
 const { publicKey: issuer, privateKey: issuerKey } = PrivateKey.randomKeypair();
-const zkAppVerifierIdentity = PrivateKey.random().toPublicKey();
+const zkAppAddress = PrivateKey.random().toPublicKey();
 
 function createOwnerSignature<Witness, Data>(
   context: Field,


### PR DESCRIPTION
This iterates on the APIs to
* create presentation requests
* parse them from JSON
* create presentations from them

In particular, we move most of the "context" creation inside our library functions, so the developer no longer has to care about:
* generating server and client nonce (these are generated automatically, randomly)
* passing in the vk hash (is derived on the client, after compiling the program)