### PR TITLE
Dynamic Strings and other arrays

### DIFF
--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -8,7 +8,7 @@ import {
   PresentationRequest,
   assert,
   type InferSchema,
-  DynamicBytes,
+  DynamicString,
 } from '../src/index.ts';
 import {
   issuer,
@@ -20,7 +20,7 @@ import {
 import { array } from '../src/o1js-missing.ts';
 
 // example schema of the credential, which has enough entropy to be hashed into a unique id
-const String = DynamicBytes({ maxLength: 50 });
+const String = DynamicString({ maxLength: 50 });
 const Bytes16 = Bytes(16);
 
 const Schema = {
@@ -44,7 +44,7 @@ const Schema = {
 // ISSUER: issue a signed credential to the owner
 
 let data: InferSchema<typeof Schema> = {
-  nationality: String.fromString('United States of America'),
+  nationality: String.from('United States of America'),
   id: Bytes16.random(),
   expiresAt: UInt64.from(Date.UTC(2028, 7, 1)),
 };
@@ -71,7 +71,7 @@ const spec = Spec(
     acceptedNations: Claim(array(String, 3)),
     acceptedIssuers: Claim(array(Field, 3)),
     currentDate: Claim(UInt64),
-    appId: Claim(Bytes16),
+    appId: Claim(String),
   },
   ({ credential, acceptedNations, acceptedIssuers, currentDate, appId }) => {
     // extract properties from the credential
@@ -106,10 +106,10 @@ const targetIssuers = [issuer, randomPublicKey(), randomPublicKey()];
 let request = PresentationRequest.https(
   spec,
   {
-    acceptedNations: targetNations.map((s) => String.fromString(s)),
+    acceptedNations: targetNations.map((s) => String.from(s)),
     acceptedIssuers: targetIssuers.map((pk) => Credential.Simple.issuer(pk)),
     currentDate: UInt64.from(Date.now()),
-    appId: Bytes16.fromString('my-app-id:123'),
+    appId: String.from('my-app-id:123'),
   },
   { action: 'my-app-id:123:authenticate' }
 );

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -8,6 +8,7 @@ import {
   PresentationRequest,
   assert,
   type InferSchema,
+  DynamicBytes,
 } from '../src/index.ts';
 import {
   issuer,
@@ -19,14 +20,14 @@ import {
 import { array } from '../src/o1js-missing.ts';
 
 // example schema of the credential, which has enough entropy to be hashed into a unique id
-const Bytes32 = Bytes(32); // TODO replace with DynamicBytes / String type once non-pure types are supported as public inputs
+const String = DynamicBytes({ maxLength: 50 });
 const Bytes16 = Bytes(16);
 
 const Schema = {
   /**
    * Nationality of the owner.
    */
-  nationality: Bytes32,
+  nationality: String,
 
   /**
    * Owner ID (16 bytes).
@@ -43,7 +44,7 @@ const Schema = {
 // ISSUER: issue a signed credential to the owner
 
 let data: InferSchema<typeof Schema> = {
-  nationality: Bytes32.fromString('United States of America'),
+  nationality: String.fromString('United States of America'),
   id: Bytes16.random(),
   expiresAt: UInt64.from(Date.UTC(2028, 7, 1)),
 };
@@ -67,10 +68,10 @@ console.log('✅ WALLET: imported and validated credential');
 const spec = Spec(
   {
     credential: Credential.Simple(Schema), // schema needed here!
-    acceptedNations: Claim(array(Bytes32, 3)),
+    acceptedNations: Claim(array(String, 3)),
     acceptedIssuers: Claim(array(Field, 3)),
     currentDate: Claim(UInt64),
-    appId: Claim(Bytes32),
+    appId: Claim(Bytes16),
   },
   ({ credential, acceptedNations, acceptedIssuers, currentDate, appId }) => {
     // extract properties from the credential
@@ -105,10 +106,10 @@ const targetIssuers = [issuer, randomPublicKey(), randomPublicKey()];
 let request = PresentationRequest.https(
   spec,
   {
-    acceptedNations: targetNations.map((s) => Bytes32.fromString(s)),
+    acceptedNations: targetNations.map((s) => String.fromString(s)),
     acceptedIssuers: targetIssuers.map((pk) => Credential.Simple.issuer(pk)),
     currentDate: UInt64.from(Date.now()),
-    appId: Bytes32.fromString('my-app-id:123'),
+    appId: Bytes16.fromString('my-app-id:123'),
   },
   { action: 'my-app-id:123:authenticate' }
 );

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -111,9 +111,7 @@ const acceptedIssuers = [issuer, randomPublicKey(), randomPublicKey()].map(
 let request = PresentationRequest.https(
   spec,
   {
-    acceptedNations: StringArray.from(
-      acceptedNations.map((s) => String.from(s))
-    ),
+    acceptedNations: StringArray.from(acceptedNations),
     acceptedIssuers: FieldArray.from(acceptedIssuers),
     currentDate: UInt64.from(Date.now()),
     appId: String.from('my-app-id:123'),
@@ -122,7 +120,10 @@ let request = PresentationRequest.https(
 );
 let requestJson = PresentationRequest.toJSON(request);
 
-console.log('✅ VERIFIER: created presentation request:', requestJson);
+console.log(
+  '✅ VERIFIER: created presentation request:',
+  requestJson.slice(0, 500) + '...'
+);
 
 // ---------------------------------------------
 // WALLET: deserialize request and create presentation

--- a/src/credentials/dynamic-array.ts
+++ b/src/credentials/dynamic-array.ts
@@ -17,8 +17,11 @@ import { assert, pad, zip } from '../util.ts';
 import { ProvableType } from '../o1js-missing.ts';
 import { assertInRange16, assertLessThan16, lessThan16 } from './gadgets.ts';
 import { ProvableFactory } from '../provable-factory.ts';
-import { serializeProvableType } from '../serialize.ts';
-import { deserializeProvableType } from '../deserialize.ts';
+import { serializeProvable, serializeProvableType } from '../serialize.ts';
+import {
+  deserializeProvable,
+  deserializeProvableType,
+} from '../deserialize.ts';
 
 export { DynamicArray };
 
@@ -442,8 +445,18 @@ ProvableFactory.register(DynamicArray, {
       innerType: serializeProvableType(constructor.prototype.innerType),
     };
   },
+
   typeFromJSON(json) {
     let innerType = deserializeProvableType(json.innerType);
     return DynamicArray(innerType, { maxLength: json.maxLength });
+  },
+
+  valueToJSON({ array, length }) {
+    return array.slice(0, Number(length)).map((v) => serializeProvable(v));
+  },
+
+  valueFromJSON(type, value) {
+    let array = value.map((v) => deserializeProvable(v));
+    return type.from(array);
   },
 });

--- a/src/credentials/dynamic-array.ts
+++ b/src/credentials/dynamic-array.ts
@@ -107,7 +107,10 @@ function DynamicArray<
       return provableArray.fromValue(input);
     }
   }
-  const provableArray = provable<T, V>(innerType, DynamicArray_);
+  const provableArray = provable<T, V, typeof DynamicArrayBase<T, V>>(
+    innerType,
+    DynamicArray_
+  );
 
   return DynamicArray_;
 }
@@ -377,15 +380,15 @@ class DynamicArrayBase<T = any, V = any> {
  */
 DynamicArray.Base = DynamicArrayBase;
 
-function provable<T, V>(
+function provable<T, V, Class extends typeof DynamicArrayBase<T, V>>(
   type: ProvablePure<T, V>,
-  Class: typeof DynamicArrayBase<T, V>
-): ProvableHashable<DynamicArrayBase<T, V>, V[]> &
-  ProvablePure<DynamicArrayBase<T, V>, V[]>;
-function provable<T, V>(
+  Class: Class
+): ProvableHashable<InstanceType<Class>, V[]> &
+  ProvablePure<InstanceType<Class>, V[]>;
+function provable<T, V, Class extends typeof DynamicArrayBase<T, V>>(
   type: Provable<T, V>,
-  Class: typeof DynamicArrayBase<T, V>
-): ProvableHashable<DynamicArrayBase<T, V>, V[]>;
+  Class: Class
+): ProvableHashable<InstanceType<Class>, V[]>;
 function provable<T, V>(
   type: Provable<T, V>,
   Class: typeof DynamicArrayBase<T, V>

--- a/src/credentials/dynamic-array.ts
+++ b/src/credentials/dynamic-array.ts
@@ -25,6 +25,8 @@ import {
 
 export { DynamicArray };
 
+export { DynamicArrayBase, provable as provableDynamicArray };
+
 type DynamicArray<T = any, V = any> = DynamicArrayBase<T, V>;
 
 type DynamicArrayClass<T, V> = typeof DynamicArrayBase<T, V> & {
@@ -440,7 +442,6 @@ function provable<T, V>(
 ProvableFactory.register(DynamicArray, {
   typeToJSON(constructor) {
     return {
-      _type: 'DynamicArray',
       maxLength: constructor.maxLength,
       innerType: serializeProvableType(constructor.prototype.innerType),
     };
@@ -451,7 +452,7 @@ ProvableFactory.register(DynamicArray, {
     return DynamicArray(innerType, { maxLength: json.maxLength });
   },
 
-  valueToJSON({ array, length }) {
+  valueToJSON(_, { array, length }) {
     return array.slice(0, Number(length)).map((v) => serializeProvable(v));
   },
 

--- a/src/credentials/dynamic-array.ts
+++ b/src/credentials/dynamic-array.ts
@@ -16,6 +16,9 @@ import {
 import { assert, pad, zip } from '../util.ts';
 import { ProvableType } from '../o1js-missing.ts';
 import { assertInRange16, assertLessThan16, lessThan16 } from './gadgets.ts';
+import { ProvableFactory } from '../provable-factory.ts';
+import { serializeProvableType } from '../serialize.ts';
+import { deserializeProvableType } from '../deserialize.ts';
 
 export { DynamicArray };
 
@@ -428,3 +431,19 @@ function provable<T, V>(
     },
   };
 }
+
+// serialize/deserialize
+
+ProvableFactory.register(DynamicArray, {
+  typeToJSON(constructor) {
+    return {
+      _type: 'DynamicArray',
+      maxLength: constructor.maxLength,
+      innerType: serializeProvableType(constructor.prototype.innerType),
+    };
+  },
+  typeFromJSON(json) {
+    let innerType = deserializeProvableType(json.innerType);
+    return DynamicArray(innerType, { maxLength: json.maxLength });
+  },
+});

--- a/src/credentials/dynamic-array.ts
+++ b/src/credentials/dynamic-array.ts
@@ -86,15 +86,13 @@ function DynamicArray<
     maxLength: number;
   }
 ): DynamicArrayClass<T, V> {
-  let innerType: Provable<T, V> = ProvableType.get(type);
-
   // assert maxLength bounds
   assert(maxLength >= 0, 'maxLength must be >= 0');
   assert(maxLength < 2 ** 16, 'maxLength must be < 2^16');
 
   class DynamicArray_ extends DynamicArrayBase<T, V> {
     get innerType() {
-      return innerType;
+      return type;
     }
     static get maxLength() {
       return maxLength;
@@ -108,7 +106,7 @@ function DynamicArray<
     }
   }
   const provableArray = provable<T, V, typeof DynamicArrayBase<T, V>>(
-    innerType,
+    ProvableType.get(type),
     DynamicArray_
   );
 
@@ -127,7 +125,7 @@ class DynamicArrayBase<T = any, V = any> {
   length: Field;
 
   // props to override
-  get innerType(): Provable<T, V> {
+  get innerType(): ProvableType<T, V> {
     throw Error('Inner type must be defined in a subclass.');
   }
   static get maxLength(): number {
@@ -193,7 +191,7 @@ class DynamicArrayBase<T = any, V = any> {
    * Cost: T*N where T = size of the type
    */
   getOrUnconstrained(i: Field): T {
-    let type = this.innerType;
+    let type = ProvableType.get(this.innerType);
     let NULL = ProvableType.synthesize(type);
     let ai = Provable.witness(type, () => this.array[Number(i)] ?? NULL);
     let aiFields = type.toFields(ai);

--- a/src/credentials/dynamic-bytes.ts
+++ b/src/credentials/dynamic-bytes.ts
@@ -31,7 +31,7 @@ function DynamicBytes({ maxLength }: { maxLength: number }) {
       return maxLength;
     }
     static get provable() {
-      return provableArray;
+      return provableBytes;
     }
 
     /**
@@ -43,7 +43,7 @@ function DynamicBytes({ maxLength }: { maxLength: number }) {
      */
     static fromBytes(bytes: Uint8Array | (number | bigint | UInt8)[] | Bytes) {
       if (bytes instanceof Bytes.Base) bytes = bytes.bytes;
-      return provableArray.fromValue(
+      return provableBytes.fromValue(
         [...bytes].map((t) => UInt8.from(t)) as any
       );
     }
@@ -69,7 +69,7 @@ function DynamicBytes({ maxLength }: { maxLength: number }) {
     }
   }
 
-  const provableArray = provableDynamicArray<
+  const provableBytes = provableDynamicArray<
     UInt8,
     { value: bigint },
     typeof DynamicBytesBase

--- a/src/credentials/dynamic-bytes.ts
+++ b/src/credentials/dynamic-bytes.ts
@@ -30,5 +30,19 @@ function DynamicBytes({ maxLength }: { maxLength: number }) {
     static fromString(s: string) {
       return DynamicBytes.fromBytes(new TextEncoder().encode(s));
     }
+
+    /**
+     * Convert DynamicBytes to a byte array.
+     */
+    static toBytes(bytes: DynamicBytes) {
+      return new Uint8Array(bytes.toValue().map(({ value }) => Number(value)));
+    }
+
+    /**
+     * Convert DynamicBytes to a string.
+     */
+    static toString(bytes: DynamicBytes) {
+      return new TextDecoder().decode(DynamicBytes.toBytes(bytes));
+    }
   };
 }

--- a/src/credentials/dynamic-sha256.ts
+++ b/src/credentials/dynamic-sha256.ts
@@ -10,14 +10,21 @@ const DynamicSHA256 = {
   /**
    * Hash a dynamic-length byte array.
    *
-   * The input type `DynamicArray<UInt8>` can be created as follows:
+   * The input type `DynamicArray<UInt8>` is compatible with both `DynamicString` and `DynamicBytes`:
    *
    * ```ts
-   * const Bytes = DynamicBytes({ maxLength: 120 });
-   * let bytes = Bytes.fromString('hello');
+   * // using DynamicString
+   * const String = DynamicString({ maxLength: 120 });
+   * let string = String.from('hello');
+   * let hash = DynamicSHA256.hash(string);
    *
+   * // using DynamicBytes
+   * const Bytes = DynamicBytes({ maxLength: 120 });
+   * let bytes = Bytes.fromHex('010203');
    * let hash = DynamicSHA256.hash(bytes);
    * ```
+   *
+   *
    */
   hash,
   /**

--- a/src/credentials/dynamic-string.ts
+++ b/src/credentials/dynamic-string.ts
@@ -1,27 +1,26 @@
 import { Bool, Bytes, Field, Provable, UInt8 } from 'o1js';
 import { DynamicArrayBase, provableDynamicArray } from './dynamic-array.ts';
 import { ProvableFactory } from '../provable-factory.ts';
-import { assert, chunk } from '../util.ts';
+import { assert } from '../util.ts';
 
-export { DynamicBytes };
+export { DynamicString };
 
 /**
- * Specialization of `DynamicArray` to bytes,
+ * Specialization of `DynamicArray` to string (represented as array of bytes),
  * with added helper methods to create instances.
  *
  * ```ts
- * const Bytes = DynamicBytes({ maxLength: 120 });
+ * const String = DynamicString({ maxLength: 120 });
  *
- * let bytes = Bytes.fromString('hello');
- * let bytes2 = Bytes.fromBytes([1, 2, 3]);
+ * let string = String.from('hello');
  * ```
  */
-function DynamicBytes({ maxLength }: { maxLength: number }) {
+function DynamicString({ maxLength }: { maxLength: number }) {
   // assert maxLength bounds
   assert(maxLength >= 0, 'maxLength must be >= 0');
   assert(maxLength < 2 ** 16, 'maxLength must be < 2^16');
 
-  class DynamicBytes extends DynamicBytesBase {
+  class DynamicString extends DynamicBytesBase {
     static get maxLength() {
       return maxLength;
     }
@@ -31,10 +30,6 @@ function DynamicBytes({ maxLength }: { maxLength: number }) {
 
     /**
      * Create DynamicBytes from a byte array in various forms.
-     *
-     * ```ts
-     * let bytes = Bytes.fromBytes([1, 2, 3]);
-     * ```
      */
     static fromBytes(bytes: Uint8Array | (number | bigint | UInt8)[] | Bytes) {
       if (bytes instanceof Bytes.Base) bytes = bytes.bytes;
@@ -44,55 +39,33 @@ function DynamicBytes({ maxLength }: { maxLength: number }) {
     }
 
     /**
-     * Create DynamicBytes from a hex string.
-     *
-     * ```ts
-     * let bytes = Bytes.fromHex('010203');
-     * ```
-     */
-    static fromHex(hex: string) {
-      assert(hex.length % 2 === 0, 'Hex string must have even length');
-      let bytes = chunk([...hex], 2).map((s) => parseInt(s.join(''), 16));
-      return DynamicBytes.fromBytes(bytes);
-    }
-
-    /**
      * Create DynamicBytes from a string.
      */
-    static fromString(s: string) {
-      return DynamicBytes.fromBytes(new TextEncoder().encode(s));
+    static from(s: string) {
+      return DynamicString.fromBytes(new TextEncoder().encode(s));
     }
 
     /**
      * Convert DynamicBytes to a byte array.
      */
-    static toBytes(bytes: DynamicBytes) {
+    static toBytes(bytes: DynamicString) {
       return new Uint8Array(bytes.toValue().map(({ value }) => Number(value)));
-    }
-
-    /**
-     * Convert DynamicBytes to a hex string.
-     */
-    static toHex(bytes: DynamicBytes) {
-      return [...DynamicBytes.toBytes(bytes)]
-        .map((b) => b.toString(16).padStart(2, '0'))
-        .join('');
     }
 
     /**
      * Convert DynamicBytes to a string.
      */
-    static toString(bytes: DynamicBytes) {
-      return new TextDecoder().decode(DynamicBytes.toBytes(bytes));
+    static toString(bytes: DynamicString) {
+      return new TextDecoder().decode(DynamicString.toBytes(bytes));
     }
   }
 
   const provableArray = provableDynamicArray<UInt8, { value: bigint }>(
     UInt8 as any,
-    DynamicBytes
+    DynamicString
   );
 
-  return DynamicBytes;
+  return DynamicString;
 }
 
 class DynamicBytesBase extends DynamicArrayBase<UInt8, { value: bigint }> {
@@ -101,24 +74,24 @@ class DynamicBytesBase extends DynamicArrayBase<UInt8, { value: bigint }> {
   }
 }
 
-DynamicBytes.Base = DynamicBytesBase;
+DynamicString.Base = DynamicBytesBase;
 
 // serialize/deserialize
 
-ProvableFactory.register(DynamicBytes, {
+ProvableFactory.register(DynamicString, {
   typeToJSON(constructor) {
     return { maxLength: constructor.maxLength };
   },
 
   typeFromJSON(json) {
-    return DynamicBytes({ maxLength: json.maxLength });
+    return DynamicString({ maxLength: json.maxLength });
   },
 
   valueToJSON(type, value) {
-    return type.toHex(value);
+    return type.toString(value);
   },
 
   valueFromJSON(type, value) {
-    return type.fromHex(value);
+    return type.from(value);
   },
 });

--- a/src/credentials/dynamic-string.ts
+++ b/src/credentials/dynamic-string.ts
@@ -28,31 +28,33 @@ function DynamicString({ maxLength }: { maxLength: number }) {
       return maxLength;
     }
     static get provable() {
-      return provableArray;
+      return provableString;
     }
 
     /**
      * Create DynamicBytes from a string.
      */
     static from(s: string) {
-      return provableArray.fromValue(s);
+      return provableString.fromValue(s);
     }
   }
 
-  const provableArray = mapValue(
+  const provableString = mapValue(
     provableDynamicArray<UInt8, { value: bigint }, typeof DynamicStringBase>(
       UInt8 as any,
       DynamicString
     ),
+    // map to string
     (s): string =>
       new TextDecoder().decode(
         new Uint8Array(s.map(({ value }) => Number(value)))
       ),
+    // map from string
     (s) => {
       if (s instanceof DynamicStringBase) return s;
-      return [...new TextEncoder().encode(s)].map((t) =>
-        UInt8.toValue(UInt8.from(t))
-      );
+      return [...new TextEncoder().encode(s)].map((t) => ({
+        value: BigInt(t),
+      }));
     }
   );
 

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -29,6 +29,7 @@ import {
 import { type CredentialType } from './credential.ts';
 import { Credential } from './credential-index.ts';
 import { array, ProvableType } from './o1js-missing.ts';
+import { ProvableFactory } from './provable-factory.ts';
 
 export {
   deserializeSpec,
@@ -213,6 +214,8 @@ function deserializeNode(
 }
 
 function deserializeProvableType(type: SerializedType): ProvableType<any> {
+  if (ProvableFactory.isSerialized(type)) return ProvableFactory.fromJSON(type);
+
   if (type._type === 'Constant') {
     return ProvableType.constant((type as any).value);
   }

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -249,11 +249,10 @@ function deserializeProvableType(type: SerializedType): ProvableType<any> {
   return result;
 }
 
-function deserializeProvable({
-  _type,
-  value,
-  properties,
-}: SerializedValue): any {
+function deserializeProvable(json: SerializedValue): any {
+  if (ProvableFactory.isSerialized(json)) return ProvableFactory.fromJSON(json);
+
+  let { _type, value, properties } = json;
   switch (_type) {
     case 'Field':
       return Field.fromJSON(value);

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -250,7 +250,8 @@ function deserializeProvableType(type: SerializedType): ProvableType<any> {
 }
 
 function deserializeProvable(json: SerializedValue): any {
-  if (ProvableFactory.isSerialized(json)) return ProvableFactory.fromJSON(json);
+  if (ProvableFactory.isSerialized(json))
+    return ProvableFactory.valueFromJSON(json);
 
   let { _type, value, properties } = json;
   switch (_type) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,6 @@ export { assert } from './util.ts';
 export { DynamicArray } from './credentials/dynamic-array.ts';
 export { StaticArray } from './credentials/static-array.ts';
 export { DynamicBytes } from './credentials/dynamic-bytes.ts';
+export { DynamicString } from './credentials/dynamic-string.ts';
 
 export type { InferProvable as InferSchema } from 'o1js';

--- a/src/o1js-missing.ts
+++ b/src/o1js-missing.ts
@@ -14,13 +14,7 @@ import {
 import { assert, assertHasProperty, hasProperty } from './util.ts';
 import type { NestedProvable } from './nested.ts';
 
-export {
-  ProvableType,
-  assertPure,
-  type ProvablePureType,
-  type InferProvableType,
-  array,
-};
+export { ProvableType, assertPure, type ProvablePureType, array };
 
 const ProvableType = {
   get<A extends WithProvable<any>>(type: A): ToProvable<A> {
@@ -124,7 +118,6 @@ type ToProvable<A extends WithProvable<any>> = A extends {
 }
   ? P
   : A;
-type InferProvableType<T extends ProvableType> = InferProvable<ToProvable<T>>;
 
 // temporary, until we land `StaticArray`
 // this is copied from o1js and then modified: https://github.com/o1-labs/o1js

--- a/src/o1js-missing.ts
+++ b/src/o1js-missing.ts
@@ -14,7 +14,7 @@ import {
 import { assert, assertHasProperty, hasProperty } from './util.ts';
 import type { NestedProvable } from './nested.ts';
 
-export { ProvableType, assertPure, type ProvablePureType, array };
+export { ProvableType, assertPure, type ProvablePureType, array, mapValue };
 
 const ProvableType = {
   get<A extends WithProvable<any>>(type: A): ToProvable<A> {
@@ -192,5 +192,48 @@ function array<A extends NestedProvable>(elementType: A, length: number) {
     _isArray: true;
     innerType: A;
     size: number;
+  };
+}
+
+// this is copied from o1js and then modified: https://github.com/o1-labs/o1js
+// License here: https://github.com/o1-labs/o1js/blob/main/LICENSE
+function mapValue<
+  A extends ProvablePure<any>,
+  V extends InferValue<A>,
+  W,
+  T extends InferProvable<A>
+>(
+  provable: A,
+  there: (x: V) => W,
+  back: (x: W | T) => V | T
+): ProvablePure<T, W>;
+
+function mapValue<
+  A extends Provable<any>,
+  V extends InferValue<A>,
+  W,
+  T extends InferProvable<A>
+>(provable: A, there: (x: V) => W, back: (x: W | T) => V | T): Provable<T, W>;
+
+function mapValue<
+  A extends Provable<any>,
+  V extends InferValue<A>,
+  W,
+  T extends InferProvable<A>
+>(provable: A, there: (x: V) => W, back: (x: W | T) => V | T): Provable<T, W> {
+  return {
+    sizeInFields: provable.sizeInFields,
+    toFields: provable.toFields,
+    toAuxiliary: provable.toAuxiliary,
+    fromFields: provable.fromFields,
+    check: provable.check,
+    toCanonical: provable.toCanonical,
+
+    toValue(value) {
+      return there(provable.toValue(value));
+    },
+    fromValue(value) {
+      return provable.fromValue(back(value));
+    },
   };
 }

--- a/src/program-spec.ts
+++ b/src/program-spec.ts
@@ -9,15 +9,10 @@ import {
   Poseidon,
   Signature,
   PublicKey,
-  Bytes,
-  Hash,
+  InferProvable,
 } from 'o1js';
 import type { ExcludeFromRecord } from './types.ts';
-import {
-  assertPure,
-  type InferProvableType,
-  ProvableType,
-} from './o1js-missing.ts';
+import { assertPure, ProvableType } from './o1js-missing.ts';
 import { assert, assertHasProperty, zip } from './util.ts';
 import {
   type InferNestedProvable,
@@ -446,8 +441,8 @@ type GetData<T extends Input> = T extends Input<infer Data> ? Data : never;
 
 function Constant<DataType extends ProvableType>(
   data: DataType,
-  value: InferProvableType<DataType>
-): Constant<InferProvableType<DataType>> {
+  value: InferProvable<DataType>
+): Constant<InferProvable<DataType>> {
   return { type: 'constant', data, value };
 }
 

--- a/src/program-spec.ts
+++ b/src/program-spec.ts
@@ -9,7 +9,7 @@ import {
   Poseidon,
   Signature,
   PublicKey,
-  InferProvable,
+  type InferProvable,
 } from 'o1js';
 import type { ExcludeFromRecord } from './types.ts';
 import { assertPure, ProvableType } from './o1js-missing.ts';
@@ -29,7 +29,6 @@ import {
   withOwner,
   type CredentialOutputs,
 } from './credential.ts';
-import { prefixes } from './constants.ts';
 
 export type {
   PublicInputs,

--- a/src/provable-factory.ts
+++ b/src/provable-factory.ts
@@ -81,7 +81,6 @@ const ProvableFactory = {
   tryValueToJSON(value: unknown): (Serialized & { value: any }) | undefined {
     let factory = ProvableFactory.getRegisteredValue(value);
     if (factory === undefined) return undefined;
-    console.log('factory', factory);
     let serializedType = factory.typeToJSON(value!.constructor as any);
     return {
       _isFactory: true as const,
@@ -107,7 +106,6 @@ const ProvableFactory = {
   },
 
   valueFromJSON(json: Serialized & { value: any }): any {
-    console.log('json', json);
     let factory = factories.get(json._type);
     assert(factory !== undefined, `Type '${json._type}' not registered`);
 

--- a/src/provable-factory.ts
+++ b/src/provable-factory.ts
@@ -1,0 +1,82 @@
+import { ProvableType } from 'o1js';
+import { assert, hasProperty } from './util.ts';
+
+export { ProvableFactory, type SerializedFactory };
+
+type Constructor<T = any> = new (...args: any) => T;
+
+/**
+ * Standard interface for polymorphic provable type that can be serialized.
+ */
+type ProvableFactory<N extends string = string, T = any, V = any> = ((
+  ...args: any
+) => Constructor<T> & ProvableType<T, V>) & {
+  name: N;
+  Base: Constructor<T>;
+};
+
+type Serializer<
+  A extends ProvableFactory = ProvableFactory,
+  S extends UntaggedSerializedFactory = UntaggedSerializedFactory
+> = {
+  typeToJSON(constructor: ReturnType<A>): S;
+
+  typeFromJSON(json: S): ReturnType<A> | undefined;
+};
+
+type SerializedFactory = {
+  _isFactory: true;
+} & UntaggedSerializedFactory;
+
+type UntaggedSerializedFactory = {
+  _type: string;
+} & Record<string, any>;
+
+const factories = new Map<
+  string,
+  { base: ProvableFactory['Base'] } & Serializer
+>();
+
+const ProvableFactory = {
+  register<A extends ProvableFactory, S extends UntaggedSerializedFactory>(
+    factory: A,
+    serialize: Serializer<A, S>
+  ) {
+    assert(!factories.has(factory.name), 'Factory already registered');
+    factories.set(factory.name, { base: factory.Base, ...serialize });
+  },
+
+  getRegistered(constructor: unknown) {
+    for (let factory of factories.values()) {
+      if (!hasProperty(constructor, 'prototype')) continue;
+      if (!(constructor.prototype instanceof factory.base)) continue;
+      return factory;
+    }
+    return undefined;
+  },
+
+  tryToJSON(constructor: unknown): SerializedFactory | undefined {
+    let factory = ProvableFactory.getRegistered(constructor);
+    if (factory === undefined) return undefined;
+
+    return Object.assign(factory.typeToJSON(constructor as any), {
+      _isFactory: true as const,
+    });
+  },
+
+  isSerialized(json: unknown): json is SerializedFactory {
+    return hasProperty(json, '_isFactory') && json._isFactory === true;
+  },
+
+  fromJSON(json: SerializedFactory): Constructor & ProvableType {
+    let factory = factories.get(json.type);
+    assert(factory !== undefined, 'Factory not registered');
+
+    let serialized = factory.typeFromJSON(json);
+    assert(
+      serialized !== undefined,
+      `Invalid serialization of type '${json.type}'`
+    );
+    return serialized;
+  },
+};

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -299,7 +299,7 @@ function serializeProvable(value: any): SerializedValue {
       return { _type, value: value.toJSON().toString() };
     }
     case UInt8: {
-      return { _type, value: (value as UInt8).toBigInt().toString() };
+      return { _type, value: (value as UInt8).toString() };
     }
     default: {
       return { _type, value: value.toJSON() };

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -20,6 +20,7 @@ import {
   Struct,
 } from 'o1js';
 import { assert } from './util.ts';
+import { ProvableFactory, type SerializedFactory } from './provable-factory.ts';
 
 export {
   type O1jsTypeName,
@@ -228,13 +229,17 @@ type SerializedType =
   | { _type: 'Constant'; value: unknown }
   | { _type: 'Bytes'; size: number }
   | { _type: 'Proof'; proof: Record<string, any> }
-  | { _type: 'String' };
+  | { _type: 'String' }
+  | SerializedFactory;
 
 type SerializedNestedType =
   | SerializedType
   | { [key: string]: SerializedNestedType };
 
 function serializeProvableType(type: ProvableType<any>): SerializedType {
+  let serialized = ProvableFactory.tryToJSON(type);
+  if (serialized !== undefined) return serialized;
+
   if ('serialize' in type && typeof type.serialize === 'function') {
     return type.serialize();
   }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -279,6 +279,9 @@ function serializeProvableType(type: ProvableType<any>): SerializedType {
 type SerializedValue = { _type: string; properties?: any; value: any };
 
 function serializeProvable(value: any): SerializedValue {
+  let serialized = ProvableFactory.tryValueToJSON(value);
+  if (serialized !== undefined) return serialized;
+
   let typeClass = ProvableType.fromValue(value);
   let { _type } = serializeProvableType(typeClass);
   if (_type === 'Bytes') {
@@ -296,7 +299,7 @@ function serializeProvable(value: any): SerializedValue {
       return { _type, value: value.toJSON().toString() };
     }
     case UInt8: {
-      return { _type, value: value.toJSON().value };
+      return { _type, value: (value as UInt8).toBigInt().toString() };
     }
     default: {
       return { _type, value: value.toJSON() };


### PR DESCRIPTION
* add infrastructure for serializing polymorphic provable types like `DynamicArray`
* add two types derived from `DynamicArray<UInt8>` with different serializations:
  * `DynamicBytes` with hex serialization
  * `DynamicString` which gets serialized as plain string
* make `equalsOneOf()` compatible with `DynamicArray` inputs
* use various dynamic array types in e2e example