### PR TITLE
Dynamic hashing

### DIFF
--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -81,9 +81,12 @@ console.log('✅ WALLET: imported and validated credential');
 // VERIFIER: request a presentation
 
 // it's enough to know a subset of the schema to create the request
+// and we don't have to use the original string lengths
+const NewString = DynamicString({ maxLength: 30 });
+
 const Subschema = DynamicRecord(
   {
-    nationality: String,
+    nationality: NewString,
     expiresAt: UInt64, // we don't have to match the original order of keys
     id: Bytes16,
   },

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -1,4 +1,4 @@
-import { Bytes, Field, Poseidon, UInt64 } from 'o1js';
+import { Bytes, Field, UInt64 } from 'o1js';
 import {
   Spec,
   Operation,
@@ -10,6 +10,7 @@ import {
   type InferSchema,
   DynamicString,
   DynamicArray,
+  hashPacked,
 } from '../src/index.ts';
 import {
   issuer,
@@ -136,7 +137,7 @@ let request = PresentationRequest.https(
   spec,
   {
     acceptedNations: FieldArray.from(
-      acceptedNations.map((s) => Poseidon.hashPacked(String, String.from(s)))
+      acceptedNations.map((s) => hashPacked(String, String.from(s)))
     ),
     acceptedIssuers: FieldArray.from(acceptedIssuers),
     currentDate: UInt64.from(Date.now()),

--- a/src/credential.ts
+++ b/src/credential.ts
@@ -13,11 +13,9 @@ import {
   type InferNestedProvable,
   NestedProvable,
   type NestedProvableFor,
-  type NestedProvablePure,
-  type NestedProvablePureFor,
 } from './nested.ts';
 import { zip } from './util.ts';
-import { hashRecord } from './credentials/dynamic-record.ts';
+import { hashRecord } from './credentials/dynamic-hash.ts';
 
 export {
   type Credential,

--- a/src/credential.ts
+++ b/src/credential.ts
@@ -260,7 +260,7 @@ function withOwner<DataType extends NestedProvable>(data: DataType) {
 function HashableCredential<Data>(
   dataType: NestedProvableFor<Data>
 ): ProvableHashable<Credential<Data>> {
-  return NestedProvable.get(withOwner(dataType)) as any;
+  return NestedProvable.get(withOwner(dataType));
 }
 
 function HashedCredential<Data>(

--- a/src/credential.ts
+++ b/src/credential.ts
@@ -15,7 +15,7 @@ import {
   type NestedProvableFor,
 } from './nested.ts';
 import { zip } from './util.ts';
-import { hashRecord } from './credentials/dynamic-hash.ts';
+import { hashDynamic } from './credentials/dynamic-hash.ts';
 
 export {
   type Credential,
@@ -271,6 +271,6 @@ function HashedCredential<Data>(
 
 function credentialHash({ owner, data }: Credential<unknown>) {
   let ownerHash = Poseidon.hash(owner.toFields());
-  let dataHash = hashRecord(data);
+  let dataHash = hashDynamic(data);
   return Poseidon.hash([ownerHash, dataHash]);
 }

--- a/src/credentials/dynamic-array.ts
+++ b/src/credentials/dynamic-array.ts
@@ -315,7 +315,6 @@ class DynamicArrayBase<T = any, V = any> {
     // TODO abstract this into a `chunk()` method that returns a DynamicArray<StaticArray<T>>
     let elementSize = bitSize(type);
     let elementsPerHalfBlock = Math.floor(254 / elementSize);
-    let fullField = elementsPerHalfBlock === 0;
     if (elementsPerHalfBlock === 0) elementsPerHalfBlock = 1; // larger types are compressed
 
     let elementsPerBlock = 2 * elementsPerHalfBlock;
@@ -344,9 +343,6 @@ class DynamicArrayBase<T = any, V = any> {
         let fields = block.array.map((el) => packToField(el, type));
         let firstHalf = fields.slice(0, elementsPerHalfBlock);
         let secondHalf = fields.slice(elementsPerHalfBlock);
-        if (fullField) {
-          return [defined(firstHalf[0]), defined(secondHalf[0])];
-        }
         return [pack(firstHalf, elementSize), pack(secondHalf, elementSize)];
       }
     );
@@ -354,15 +350,6 @@ class DynamicArrayBase<T = any, V = any> {
     // add length to the first block
     let firstBlock = blocks.array[0]!;
     firstBlock.set(0, firstBlock.get(0).add(this.length).seal());
-
-    // TODO remove
-    // Provable.log({
-    //   elementsPerUint32,
-    //   elementSize,
-    //   elementsPerBlock,
-    //   maxBlocks,
-    //   hash: blocks.array.flatMap((x) => x.array),
-    // });
 
     // now hash the 2-field elements blocks, on permutation at a time
     // TODO: first we hash the length, but this should be included in the rest

--- a/src/credentials/dynamic-array.ts
+++ b/src/credentials/dynamic-array.ts
@@ -348,13 +348,16 @@ class DynamicArrayBase<T = any, V = any> {
 
     let Fieldx2 = StaticArray(Field, 2);
     let Blocks = DynamicArray(Fieldx2, { maxLength: maxBlocks });
+
     // nBlocks = ceil(length / elementsPerBlock) = floor((length + elementsPerBlock - 1) / elementsPerBlock)
     let nBlocks = UInt32.Unsafe.fromField(
       this.length.add(elementsPerUint32 + elementsPerBlock - 1)
     ).div(elementsPerBlock).value;
     let dynBlocks = new Blocks(blocks.map(Fieldx2.from), nBlocks);
 
-    // now hash the 2-field elements blocks, on permutation at a time
+    // now hash the 2-field elements blocks, one permutation at a time
+    // note: there's a padding element included at the end in the case of uneven number of blocks
+    // however, this doesn't cause hash collisions because we encoded the length at the beginning
     let state = Poseidon.initialState();
     dynBlocks.forEach((block, isPadding) => {
       let newState = Poseidon.update(state, block.array);

--- a/src/credentials/dynamic-array.ts
+++ b/src/credentials/dynamic-array.ts
@@ -511,11 +511,15 @@ function provable<T, V, Class extends typeof DynamicArrayBase<T, V>>(
         there({ array, length }) {
           return array.slice(0, Number(length));
         },
-        back(array) {
+        backAndDistinguish(array) {
+          // gracefully handle different maxLength
+          if (array instanceof DynamicArrayBase) {
+            if (array.maxLength === maxLength) return array;
+            array = array.toValue();
+          }
           let padded = pad(array, maxLength, NULL);
           return { array: padded, length: BigInt(array.length) };
         },
-        distinguish: (s) => s instanceof DynamicArrayBase,
       })
 
       // custom hash input

--- a/src/credentials/dynamic-array.ts
+++ b/src/credentials/dynamic-array.ts
@@ -335,10 +335,10 @@ class DynamicArrayBase<T = any, V = any> {
       (block) => {
         let firstHalf = block.array
           .slice(0, elementsPerHalfBlock)
-          .map((el) => packToField(type, el));
+          .map((el) => packToField(el, type));
         let secondHalf = block.array
           .slice(elementsPerHalfBlock)
-          .map((el) => packToField(type, el));
+          .map((el) => packToField(el, type));
         return [pack(firstHalf, elementSize), pack(secondHalf, elementSize)];
       }
     );

--- a/src/credentials/dynamic-array.ts
+++ b/src/credentials/dynamic-array.ts
@@ -13,15 +13,7 @@ import {
   type IsPure,
   Poseidon,
 } from 'o1js';
-import {
-  assert,
-  assertHasProperty,
-  chunk,
-  defined,
-  fill,
-  pad,
-  zip,
-} from '../util.ts';
+import { assert, assertHasProperty, chunk, fill, pad, zip } from '../util.ts';
 import {
   type ProvableHashablePure,
   type ProvableHashableType,
@@ -134,7 +126,7 @@ function DynamicArray<
 
   return DynamicArray_;
 }
-BaseType.set('DynamicArray', DynamicArray);
+BaseType.DynamicArray = DynamicArray;
 
 class DynamicArrayBase<T = any, V = any> {
   /**

--- a/src/credentials/dynamic-array.ts
+++ b/src/credentials/dynamic-array.ts
@@ -317,6 +317,7 @@ class DynamicArrayBase<T = any, V = any> {
     // create blocks of 2 field elements each
     // TODO abstract this into a `chunk()` method that returns a DynamicArray<StaticArray<T>>
     let elementSize = bitSize(type);
+    if (elementSize === 0) elementSize = 1; // edge case for empty types like `Undefined`
     let elementsPerHalfBlock = Math.floor(254 / elementSize);
     if (elementsPerHalfBlock === 0) elementsPerHalfBlock = 1; // larger types are compressed
 

--- a/src/credentials/dynamic-array.ts
+++ b/src/credentials/dynamic-array.ts
@@ -36,6 +36,7 @@ import {
 import { TypeBuilder, TypeBuilderPure } from '../provable-type-builder.ts';
 import { StaticArray } from './static-array.ts';
 import { bitSize, packedFieldSize, packToField } from './dynamic-hash.ts';
+import { BaseType } from './dynamic-base-types.ts';
 
 export { DynamicArray };
 
@@ -126,6 +127,7 @@ function DynamicArray<
 
   return DynamicArray_;
 }
+BaseType.set('DynamicArray', DynamicArray);
 
 class DynamicArrayBase<T = any, V = any> {
   /**

--- a/src/credentials/dynamic-array.ts
+++ b/src/credentials/dynamic-array.ts
@@ -343,9 +343,9 @@ class DynamicArrayBase<T = any, V = any> {
     let firstBlock = blocks[0]!;
     firstBlock[0] = firstBlock[0].add(this.length).seal();
 
-    // nBlocks = ceil(length / elementsPerBlock) = floor((length + elementsPerBlock - 1) / elementsPerBlock)
     let Fieldx2 = StaticArray(Field, 2);
     let Blocks = DynamicArray(Fieldx2, { maxLength: maxBlocks });
+    // nBlocks = ceil(length / elementsPerBlock) = floor((length + elementsPerBlock - 1) / elementsPerBlock)
     let nBlocks = UInt32.Unsafe.fromField(
       this.length.add(elementsPerUint32 + elementsPerBlock - 1)
     ).div(elementsPerBlock).value;

--- a/src/credentials/dynamic-array.ts
+++ b/src/credentials/dynamic-array.ts
@@ -313,14 +313,12 @@ class DynamicArrayBase<T = any, V = any> {
 
     // create blocks of 2 field elements each
     // TODO abstract this into a `chunk()` method that returns a DynamicArray<StaticArray<T>>
-    let mustPack = packedFieldSize(type) > 1;
     let elementSize = bitSize(type);
     let elementsPerHalfBlock = Math.floor(254 / elementSize);
     let fullField = elementsPerHalfBlock === 0;
     if (elementsPerHalfBlock === 0) elementsPerHalfBlock = 1; // larger types are compressed
 
     let elementsPerBlock = 2 * elementsPerHalfBlock;
-    assert(!mustPack, 'TODO'); // this should get a separate branch here
 
     // we pack the length at the beginning of the first block
     // for efficiency (to avoid unpacking the length), we first put zeros at the beginning
@@ -343,12 +341,9 @@ class DynamicArrayBase<T = any, V = any> {
     let blocks = new Blocks(chunked, nBlocks).map(
       StaticArray(Field, 2),
       (block) => {
-        let firstHalf = block.array
-          .slice(0, elementsPerHalfBlock)
-          .map((el) => packToField(el, type));
-        let secondHalf = block.array
-          .slice(elementsPerHalfBlock)
-          .map((el) => packToField(el, type));
+        let fields = block.array.map((el) => packToField(el, type));
+        let firstHalf = fields.slice(0, elementsPerHalfBlock);
+        let secondHalf = fields.slice(elementsPerHalfBlock);
         if (fullField) {
           return [defined(firstHalf[0]), defined(secondHalf[0])];
         }

--- a/src/credentials/dynamic-array.ts
+++ b/src/credentials/dynamic-array.ts
@@ -307,6 +307,7 @@ class DynamicArrayBase<T = any, V = any> {
     let mustPack = packedFieldSize(type) > 1;
     let elementSize = bitSize(type);
     let elementsPerHalfBlock = Math.floor(254 / elementSize);
+    let fullField = elementsPerHalfBlock === 0;
     if (elementsPerHalfBlock === 0) elementsPerHalfBlock = 1; // larger types are compressed
 
     let elementsPerBlock = 2 * elementsPerHalfBlock;
@@ -339,6 +340,7 @@ class DynamicArrayBase<T = any, V = any> {
         let secondHalf = block.array
           .slice(elementsPerHalfBlock)
           .map((el) => packToField(el, type));
+        if (fullField) return [firstHalf[0]!, secondHalf[1]!];
         return [pack(firstHalf, elementSize), pack(secondHalf, elementSize)];
       }
     );

--- a/src/credentials/dynamic-base-types.ts
+++ b/src/credentials/dynamic-base-types.ts
@@ -4,7 +4,7 @@
 import type { DynamicArray } from './dynamic-array.ts';
 import type { DynamicString } from './dynamic-string.ts';
 import type { DynamicRecord, GenericRecord } from './dynamic-record.ts';
-import { assertDefined } from '../util.ts';
+import { Required } from '../util.ts';
 
 export { BaseType };
 
@@ -14,26 +14,5 @@ let baseType: {
   DynamicRecord?: typeof DynamicRecord;
   GenericRecord?: typeof GenericRecord;
 } = {};
-type BaseType = typeof baseType;
 
-const BaseType = {
-  set<K extends keyof BaseType>(key: K, value: BaseType[K]) {
-    baseType[key] = value;
-  },
-  get DynamicArray() {
-    assertDefined(baseType.DynamicArray);
-    return baseType.DynamicArray;
-  },
-  get DynamicString() {
-    assertDefined(baseType.DynamicString);
-    return baseType.DynamicString;
-  },
-  get DynamicRecord() {
-    assertDefined(baseType.DynamicRecord);
-    return baseType.DynamicRecord;
-  },
-  get GenericRecord() {
-    assertDefined(baseType.GenericRecord);
-    return baseType.GenericRecord;
-  },
-};
+const BaseType = Required(baseType);

--- a/src/credentials/dynamic-base-types.ts
+++ b/src/credentials/dynamic-base-types.ts
@@ -1,0 +1,39 @@
+/**
+ * This file is just a hack to break import cycles
+ */
+import type { DynamicArray } from './dynamic-array.ts';
+import type { DynamicString } from './dynamic-string.ts';
+import type { DynamicRecord, GenericRecord } from './dynamic-record.ts';
+import { assertDefined } from '../util.ts';
+
+export { BaseType };
+
+let baseType: {
+  DynamicArray?: typeof DynamicArray;
+  DynamicString?: typeof DynamicString;
+  DynamicRecord?: typeof DynamicRecord;
+  GenericRecord?: typeof GenericRecord;
+} = {};
+type BaseType = typeof baseType;
+
+const BaseType = {
+  set<K extends keyof BaseType>(key: K, value: BaseType[K]) {
+    baseType[key] = value;
+  },
+  get DynamicArray() {
+    assertDefined(baseType.DynamicArray);
+    return baseType.DynamicArray;
+  },
+  get DynamicString() {
+    assertDefined(baseType.DynamicString);
+    return baseType.DynamicString;
+  },
+  get DynamicRecord() {
+    assertDefined(baseType.DynamicRecord);
+    return baseType.DynamicRecord;
+  },
+  get GenericRecord() {
+    assertDefined(baseType.GenericRecord);
+    return baseType.GenericRecord;
+  },
+};

--- a/src/credentials/dynamic-bytes.ts
+++ b/src/credentials/dynamic-bytes.ts
@@ -1,4 +1,4 @@
-import { Bool, Bytes, Field, Provable, UInt8 } from 'o1js';
+import { Bool, Bytes, Field, type ProvableHashable, UInt8 } from 'o1js';
 import { DynamicArrayBase, provableDynamicArray } from './dynamic-array.ts';
 import { ProvableFactory } from '../provable-factory.ts';
 import { assert, chunk } from '../util.ts';
@@ -80,7 +80,7 @@ function DynamicBytes({ maxLength }: { maxLength: number }) {
 
 class DynamicBytesBase extends DynamicArrayBase<UInt8, { value: bigint }> {
   get innerType() {
-    return UInt8 as any as Provable<UInt8, { value: bigint }>;
+    return UInt8 as any as ProvableHashable<UInt8, { value: bigint }>;
   }
 
   /**

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -18,20 +18,18 @@ let longHash = hashString(longString);
 
 async function main() {
   await test('hash strings', () => {
-    Provable.witness(ShortString, () => shortString)
-      .hash()
-      .assertEquals(shortHash, 'hash mismatch (short)');
+    let shortStringVar = Provable.witness(ShortString, () => shortString);
+    shortStringVar.hash().assertEquals(shortHash, 'short string');
 
-    LongString.from(longString)
-      .hash()
-      .assertEquals(longHash, 'hash mismatch (long)');
+    let longStringVar = Provable.witness(LongString, () => longString);
+    longStringVar.hash().assertEquals(longHash, 'long string');
 
     // we can even convert the `ShortString` into a `LongString`
-    Provable.witness(LongString, () => ShortString.from(shortString))
+    LongString.from(shortStringVar)
       .hash()
-      .assertEquals(shortHash, 'hash mismatch (short -> long)');
+      .assertEquals(shortHash, 'short -> long string');
 
-    // (the other way round doesn't work because the string is too long)
+    // the other way round doesn't work because the string is too long
     nodeAssert.throws(() => {
       ShortString.from(LongString.from(longString));
     }, /larger than target size/);
@@ -46,13 +44,13 @@ async function main() {
   let longArrayHash = hashDynamic(longArray);
 
   await test('hash arrays of strings', () => {
-    Provable.witness(ShortArray, () => [shortString, shortString])
+    Provable.witness(ShortArray, () => shortArray)
       .hash()
-      .assertEquals(shortArrayHash, 'hash mismatch (short array)');
+      .assertEquals(shortArrayHash, 'short array');
 
-    Provable.witness(LongArray, () => Array(8).fill(longString))
+    Provable.witness(LongArray, () => longArray)
       .hash()
-      .assertEquals(longArrayHash, 'hash mismatch (long array)');
+      .assertEquals(longArrayHash, 'long array');
   });
 }
 

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -86,11 +86,11 @@ async function main() {
 
   let RecordArray = DynamicArray(Record, { maxLength: 5 });
 
-  // await test('hash arrays of records', () => {
-  Provable.witness(RecordArray, () => array)
-    .hash()
-    .assertEquals(arrayHash, 'array');
-  // });
+  await test('hash arrays of records', () => {
+    Provable.witness(RecordArray, () => array)
+      .hash()
+      .assertEquals(arrayHash, 'array');
+  });
 }
 
 await test('outside circuit', () => main());

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -1,7 +1,13 @@
 import { DynamicArray } from './dynamic-array.ts';
 import { DynamicString } from './dynamic-string.ts';
 import './dynamic-record.ts';
-import { hashDynamic, hashString, packToField } from './dynamic-hash.ts';
+import {
+  hashArray,
+  hashDynamic,
+  hashRecord,
+  hashString,
+  packToField,
+} from './dynamic-hash.ts';
 import { test } from 'node:test';
 import * as nodeAssert from 'node:assert';
 import { Bytes, Field, MerkleList, Poseidon, Provable, UInt8 } from 'o1js';
@@ -52,17 +58,18 @@ async function main() {
   let longArrayHash = hashDynamic(longArray);
 
   await test('hash arrays of strings', () => {
-    Provable.witness(ShortArray, () => shortArray)
-      .hash()
-      .assertEquals(shortArrayHash, 'short array');
+    let shortArrayVar = Provable.witness(ShortArray, () => shortArray);
+    shortArrayVar.hash().assertEquals(shortArrayHash, 'short array');
 
     Provable.witness(LongArray, () => longArray)
       .hash()
       .assertEquals(longArrayHash, 'long array');
 
     // for arrays, hashDynamic === packToField === hashArray
-    hashDynamic(shortArray).assertEquals(shortArrayHash, 'short array');
+    hashArray(shortArray).assertEquals(shortArrayHash, 'short array');
     packToField(shortArray).assertEquals(shortArrayHash, 'short array');
+    hashDynamic(shortArrayVar).assertEquals(shortArrayHash, 'short array');
+    packToField(shortArrayVar).assertEquals(shortArrayHash, 'short array');
   });
 
   // single-field values
@@ -87,9 +94,11 @@ async function main() {
   let Record = DynamicRecord({}, { maxEntries: 5 });
 
   await test('hash records', () => {
-    Provable.witness(Record, () => record)
-      .hash()
-      .assertEquals(recordHash, 'record');
+    let recordVar = Provable.witness(Record, () => record);
+    recordVar.hash().assertEquals(recordHash, 'record');
+
+    packToField(recordVar).assertEquals(recordHash, 'record');
+    hashRecord(record).assertEquals(recordHash, 'record');
   });
 
   // arrays of records

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -34,6 +34,12 @@ async function main() {
     nodeAssert.throws(() => {
       ShortString.from(LongString.from(longString));
     }, /larger than target size/);
+
+    // for strings, hashDynamic === packToField === hashString
+    hashDynamic(shortString).assertEquals(shortHash, 'short string');
+    packToField(shortString).assertEquals(shortHash, 'short string');
+    hashDynamic(shortStringVar).assertEquals(shortHash, 'short string');
+    packToField(shortStringVar).assertEquals(shortHash, 'short string');
   });
 
   // arrays of strings
@@ -53,6 +59,10 @@ async function main() {
     Provable.witness(LongArray, () => longArray)
       .hash()
       .assertEquals(longArrayHash, 'long array');
+
+    // for arrays, hashDynamic === packToField === hashArray
+    hashDynamic(shortArray).assertEquals(shortArrayHash, 'short array');
+    packToField(shortArray).assertEquals(shortArrayHash, 'short array');
   });
 
   // single-field values
@@ -61,12 +71,13 @@ async function main() {
     packToField(-1n).assertEquals(Field(-1n), 'pack bigint');
     packToField(true).assertEquals(Field(1), 'pack boolean');
     packToField(123).assertEquals(Field(123), 'pack number');
-    // packDynamic(undefined).assertEquals(Field(0), 'pack undefined');
+    packToField(undefined).assertEquals(Poseidon.hash([]), 'pack undefined');
 
     // hash is plain poseidon hash
     hashDynamic(-1n).assertEquals(Poseidon.hash([Field(-1n)]), 'hash bigint');
     hashDynamic(true).assertEquals(Poseidon.hash([Field(1)]), 'hash boolean');
     hashDynamic(123).assertEquals(Poseidon.hash([Field(123)]), 'hash number');
+    hashDynamic(undefined).assertEquals(Poseidon.hash([]), 'pack undefined');
   });
 
   // records of plain values

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -79,6 +79,18 @@ async function main() {
       .hash()
       .assertEquals(recordHash, 'record');
   });
+
+  // arrays of records
+  let array = [record, record, record];
+  let arrayHash = hashDynamic(array);
+
+  let RecordArray = DynamicArray(Record, { maxLength: 5 });
+
+  // await test('hash arrays of records', () => {
+  Provable.witness(RecordArray, () => array)
+    .hash()
+    .assertEquals(arrayHash, 'array');
+  // });
 }
 
 await test('outside circuit', () => main());

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -140,9 +140,10 @@ async function main() {
   let RecordArray = DynamicArray(Record, { maxLength: 5 });
 
   await test('hash arrays of records', () => {
-    Provable.witness(RecordArray, () => array)
-      .hash()
-      .assertEquals(arrayHash, 'array');
+    let arrayVar = Provable.witness(RecordArray, () => array);
+
+    arrayVar.hash().assertEquals(arrayHash, 'array');
+    hashDynamic(array).assertEquals(arrayHash, 'array');
   });
 }
 

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -1,6 +1,7 @@
 import { DynamicArray } from './dynamic-array.ts';
 import { DynamicString } from './dynamic-string.ts';
-import { hashString, packToField } from './dynamic-hash.ts';
+import './dynamic-record.ts';
+import { hashDynamic, hashString } from './dynamic-hash.ts';
 import { test } from 'node:test';
 import * as nodeAssert from 'node:assert';
 
@@ -36,15 +37,16 @@ test('hash strings', () => {
 });
 
 let ShortArray = DynamicArray(ShortString, { maxLength: 5 });
+let LongArray = DynamicArray(LongString, { maxLength: 5 });
 
 test('hash arrays', () => {
-  let shortArrayHash = packToField([shortString, shortString]);
+  let shortArrayHash = hashDynamic([shortString, shortString]);
   ShortArray.from([shortString, shortString])
     .hash()
     .assertEquals(shortArrayHash, 'hash mismatch (short array)');
 
-  let longArrayHash = packToField([longString, longString]);
-  ShortArray.from([longString, longString])
+  let longArrayHash = hashDynamic([longString, longString]);
+  LongArray.from([longString, longString])
     .hash()
     .assertEquals(longArrayHash, 'hash mismatch (long array)');
 });

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -1,0 +1,18 @@
+import { DynamicArray } from './dynamic-array.ts';
+import { DynamicString } from './dynamic-string.ts';
+import { hashString } from './dynamic-hash.ts';
+
+let shortString = 'hi';
+let ShortString = DynamicString({ maxLength: 5 });
+
+let longString =
+  'Poseidon (/pəˈsaɪdən, pɒ-, poʊ-/;[1] Greek: Ποσειδῶν) is one of the Twelve Olympians in ancient Greek religion and mythology,' +
+  ' presiding over the sea, storms, earthquakes and horses.[2]';
+let LongString = DynamicString({ maxLength: 300 });
+
+ShortString.from(shortString)
+  .hash()
+  .assertEquals(hashString(shortString), 'hash mismatch (short)');
+LongString.from(longString)
+  .hash()
+  .assertEquals(hashString(longString), 'hash mismatch (long)');

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -6,12 +6,25 @@ import {
   hashDynamic,
   hashRecord,
   hashString,
+  packStringToField,
   packToField,
 } from './dynamic-hash.ts';
 import { test } from 'node:test';
 import * as nodeAssert from 'node:assert';
 import { Bytes, Field, MerkleList, Poseidon, Provable, UInt8 } from 'o1js';
 import { DynamicRecord } from './dynamic-record.ts';
+
+// some hash collisions to be aware of
+hashDynamic(5).assertEquals(hashDynamic(5n), '1');
+hashDynamic(undefined).assertEquals(hashDynamic(null), '2');
+hashDynamic([0]).assertEquals(hashDynamic('\x00'), '3');
+hashDynamic([1, 2].map(UInt8.from)).assertEquals(hashDynamic('\x01\x02'), '4');
+
+// TODO: this is a hash collision we need to fix
+let emptyString = packStringToField('\x00').toBigInt();
+let emptyValue = packToField(0).toBigInt();
+console.log({ emptyString, emptyValue });
+hashRecord({ '\x00': 0 }).assertEquals(hashRecord({}));
 
 let shortString = 'hi';
 let ShortString = DynamicString({ maxLength: 5 });

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -1,7 +1,7 @@
 import { DynamicArray } from './dynamic-array.ts';
 import { DynamicString } from './dynamic-string.ts';
 import './dynamic-record.ts';
-import { hashDynamic, hashString, packDynamic } from './dynamic-hash.ts';
+import { hashDynamic, hashString, packToField } from './dynamic-hash.ts';
 import { test } from 'node:test';
 import * as nodeAssert from 'node:assert';
 import { Bytes, Field, MerkleList, Poseidon, Provable, UInt8 } from 'o1js';
@@ -58,9 +58,10 @@ async function main() {
   // single-field values
   await test('plain values', () => {
     // stay the same when packing
-    packDynamic(-1n).assertEquals(Field(-1n), 'pack bigint');
-    packDynamic(true).assertEquals(Field(1), 'pack boolean');
-    packDynamic(123).assertEquals(Field(123), 'pack number');
+    packToField(-1n).assertEquals(Field(-1n), 'pack bigint');
+    packToField(true).assertEquals(Field(1), 'pack boolean');
+    packToField(123).assertEquals(Field(123), 'pack number');
+    // packDynamic(undefined).assertEquals(Field(0), 'pack undefined');
 
     // hash is plain poseidon hash
     hashDynamic(-1n).assertEquals(Poseidon.hash([Field(-1n)]), 'hash bigint');

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -6,25 +6,44 @@ import {
   hashDynamic,
   hashRecord,
   hashString,
-  packStringToField,
   packToField,
 } from './dynamic-hash.ts';
 import { test } from 'node:test';
 import * as nodeAssert from 'node:assert';
-import { Bytes, Field, MerkleList, Poseidon, Provable, UInt8 } from 'o1js';
+import {
+  Bytes,
+  Field,
+  MerkleList,
+  Poseidon,
+  Provable,
+  UInt32,
+  UInt8,
+} from 'o1js';
 import { DynamicRecord } from './dynamic-record.ts';
 
-// some hash collisions to be aware of
-hashDynamic(5).assertEquals(hashDynamic(5n), '1');
-hashDynamic(undefined).assertEquals(hashDynamic(null), '2');
-hashDynamic([0]).assertEquals(hashDynamic('\x00'), '3');
-hashDynamic([1, 2].map(UInt8.from)).assertEquals(hashDynamic('\x01\x02'), '4');
+// some hash collisions to be aware of, that are also quite natural
 
-// TODO: this is a hash collision we need to fix
-let emptyString = packStringToField('\x00').toBigInt();
-let emptyValue = packToField(0).toBigInt();
-console.log({ emptyString, emptyValue });
-hashRecord({ '\x00': 0 }).assertEquals(hashRecord({}));
+hashDynamic(5n).assertEquals(hashDynamic(5), 'bigint ~ number');
+hashDynamic(true).assertEquals(hashDynamic(1), 'bool ~ number');
+hashDynamic({ a: 0n }).assertEquals(
+  hashDynamic({ a: false }),
+  'record ~ record with equivalent fields'
+);
+hashDynamic(undefined).assertEquals(
+  hashDynamic(null),
+  'undefined ~ null ~ any empty type'
+);
+hashDynamic('\x01\x02').assertEquals(
+  hashDynamic([1, 2].map(UInt8.from)),
+  'strings ~ dynamic arrays of bytes'
+);
+hashDynamic([UInt32.from(0)]).assertEquals(
+  hashDynamic([Field(0)]),
+  'dynamic arrays of zeros of same length, regardless of packing density of type (because padding is zeros)'
+);
+
+// this used to be an unexpected hash collision that was fixed
+hashRecord({ '\x00': 0 }).assertNotEquals(hashRecord({}));
 
 let shortString = 'hi';
 let ShortString = DynamicString({ maxLength: 5 });

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -1,6 +1,7 @@
 import { DynamicArray } from './dynamic-array.ts';
 import { DynamicString } from './dynamic-string.ts';
 import { hashString } from './dynamic-hash.ts';
+import { test } from 'node:test';
 
 let shortString = 'hi';
 let ShortString = DynamicString({ maxLength: 5 });
@@ -10,9 +11,12 @@ let longString =
   ' presiding over the sea, storms, earthquakes and horses.[2]';
 let LongString = DynamicString({ maxLength: 300 });
 
-ShortString.from(shortString)
-  .hash()
-  .assertEquals(hashString(shortString), 'hash mismatch (short)');
-LongString.from(longString)
-  .hash()
-  .assertEquals(hashString(longString), 'hash mismatch (long)');
+test('hash strings', () => {
+  ShortString.from(shortString)
+    .hash()
+    .assertEquals(hashString(shortString), 'hash mismatch (short)');
+
+  LongString.from(longString)
+    .hash()
+    .assertEquals(hashString(longString), 'hash mismatch (long)');
+});

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -1,6 +1,6 @@
 import { DynamicArray } from './dynamic-array.ts';
 import { DynamicString } from './dynamic-string.ts';
-import { hashString } from './dynamic-hash.ts';
+import { hashString, packToField } from './dynamic-hash.ts';
 import { test } from 'node:test';
 import * as nodeAssert from 'node:assert';
 
@@ -33,4 +33,18 @@ test('hash strings', () => {
   nodeAssert.throws(() => {
     ShortString.provable.fromValue(LongString.from(longString));
   }, /larger than target size/);
+});
+
+let ShortArray = DynamicArray(ShortString, { maxLength: 5 });
+
+test('hash arrays', () => {
+  let shortArrayHash = packToField([shortString, shortString]);
+  ShortArray.from([shortString, shortString])
+    .hash()
+    .assertEquals(shortArrayHash, 'hash mismatch (short array)');
+
+  let longArrayHash = packToField([longString, longString]);
+  ShortArray.from([longString, longString])
+    .hash()
+    .assertEquals(longArrayHash, 'hash mismatch (long array)');
 });

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -4,49 +4,77 @@ import './dynamic-record.ts';
 import { hashDynamic, hashString } from './dynamic-hash.ts';
 import { test } from 'node:test';
 import * as nodeAssert from 'node:assert';
+import { Bytes, MerkleList, Poseidon, Provable, UInt8 } from 'o1js';
 
 let shortString = 'hi';
 let ShortString = DynamicString({ maxLength: 5 });
+let shortHash = hashString(shortString);
 
 let longString =
-  'Poseidon (/pəˈsaɪdən, pɒ-, poʊ-/;[1] Greek: Ποσειδῶν) is one of the Twelve Olympians in ancient Greek religion and mythology,' +
-  ' presiding over the sea, storms, earthquakes and horses.[2]';
-let LongString = DynamicString({ maxLength: 300 });
+  'Poseidon (/pəˈsaɪdən, pɒ-, poʊ-/;[1] Greek: Ποσειδῶν) is one of the Twelve Olympians';
 
-test('hash strings', () => {
-  let shortHash = hashString(shortString);
-  ShortString.from(shortString)
-    .hash()
-    .assertEquals(shortHash, 'hash mismatch (short)');
+let LongString = DynamicString({ maxLength: 100 });
+let longHash = hashString(longString);
 
-  let longHash = hashString(longString);
-  LongString.from(longString)
-    .hash()
-    .assertEquals(longHash, 'hash mismatch (long)');
+async function main() {
+  await test('hash strings', () => {
+    Provable.witness(ShortString, () => shortString)
+      .hash()
+      .assertEquals(shortHash, 'hash mismatch (short)');
 
-  // we can even convert the `ShortString` into a `LongString`
-  LongString.provable
-    .fromValue(ShortString.from(shortString))
-    .hash()
-    .assertEquals(shortHash, 'hash mismatch (short -> long)');
+    LongString.from(longString)
+      .hash()
+      .assertEquals(longHash, 'hash mismatch (long)');
 
-  // (the other way round doesn't work because the string is too long)
-  nodeAssert.throws(() => {
-    ShortString.provable.fromValue(LongString.from(longString));
-  }, /larger than target size/);
+    // we can even convert the `ShortString` into a `LongString`
+    Provable.witness(LongString, () => ShortString.from(shortString))
+      .hash()
+      .assertEquals(shortHash, 'hash mismatch (short -> long)');
+
+    // (the other way round doesn't work because the string is too long)
+    nodeAssert.throws(() => {
+      ShortString.from(LongString.from(longString));
+    }, /larger than target size/);
+  });
+
+  let shortArray = [shortString, shortString];
+  let ShortArray = DynamicArray(ShortString, { maxLength: 5 });
+  let longArray = Array(8).fill(longString);
+  let LongArray = DynamicArray(LongString, { maxLength: 10 });
+
+  let shortArrayHash = hashDynamic(shortArray);
+  let longArrayHash = hashDynamic(longArray);
+
+  await test('hash arrays of strings', () => {
+    Provable.witness(ShortArray, () => [shortString, shortString])
+      .hash()
+      .assertEquals(shortArrayHash, 'hash mismatch (short array)');
+
+    Provable.witness(LongArray, () => Array(8).fill(longString))
+      .hash()
+      .assertEquals(longArrayHash, 'hash mismatch (long array)');
+  });
+}
+
+await test('outside circuit', () => main());
+await test('inside circuit', () => Provable.runAndCheck(main));
+
+// comparison of constraint efficiency of different approaches
+
+let cs = await Provable.constraintSystem(() => {
+  Provable.witness(LongString, () => longString).hash();
 });
+console.log('constraints: string hash (100)', cs.rows);
 
-let ShortArray = DynamicArray(ShortString, { maxLength: 5 });
-let LongArray = DynamicArray(LongString, { maxLength: 5 });
+// merkle list of characters
+// list is represented as a single hash, so the equivalent of hashing is unpacking the entire list
+let CharList = MerkleList.create(UInt8, (hash, { value }) =>
+  Poseidon.hash([hash, value])
+);
 
-test('hash arrays', () => {
-  let shortArrayHash = hashDynamic([shortString, shortString]);
-  ShortArray.from([shortString, shortString])
-    .hash()
-    .assertEquals(shortArrayHash, 'hash mismatch (short array)');
-
-  let longArrayHash = hashDynamic([longString, longString]);
-  LongArray.from([longString, longString])
-    .hash()
-    .assertEquals(longArrayHash, 'hash mismatch (long array)');
+let cs2 = await Provable.constraintSystem(() => {
+  Provable.witness(CharList, () =>
+    CharList.from(Bytes.fromString(longString).bytes)
+  ).forEach(100, (_item, _isDummy) => {});
 });
+console.log('constraints: merkle list of chars (100)', cs2.rows);

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -2,6 +2,7 @@ import { DynamicArray } from './dynamic-array.ts';
 import { DynamicString } from './dynamic-string.ts';
 import { hashString } from './dynamic-hash.ts';
 import { test } from 'node:test';
+import * as nodeAssert from 'node:assert';
 
 let shortString = 'hi';
 let ShortString = DynamicString({ maxLength: 5 });
@@ -12,11 +13,24 @@ let longString =
 let LongString = DynamicString({ maxLength: 300 });
 
 test('hash strings', () => {
+  let shortHash = hashString(shortString);
   ShortString.from(shortString)
     .hash()
-    .assertEquals(hashString(shortString), 'hash mismatch (short)');
+    .assertEquals(shortHash, 'hash mismatch (short)');
 
+  let longHash = hashString(longString);
   LongString.from(longString)
     .hash()
-    .assertEquals(hashString(longString), 'hash mismatch (long)');
+    .assertEquals(longHash, 'hash mismatch (long)');
+
+  // we can even convert the `ShortString` into a `LongString`
+  LongString.provable
+    .fromValue(ShortString.from(shortString))
+    .hash()
+    .assertEquals(shortHash, 'hash mismatch (short -> long)');
+
+  // (the other way round doesn't work because the string is too long)
+  nodeAssert.throws(() => {
+    ShortString.provable.fromValue(LongString.from(longString));
+  }, /larger than target size/);
 });

--- a/src/credentials/dynamic-hash.ts
+++ b/src/credentials/dynamic-hash.ts
@@ -26,11 +26,15 @@ const enc = new TextEncoder();
 
 function hashString(string: string) {
   // encode length + bytes
-  let bytes = enc.encode(string);
-  let length = bytes.length;
-  let B = Bytes(length);
+  let stringBytes = enc.encode(string);
+  let length = stringBytes.length;
+  let bytes = new Uint8Array(4 + length);
+  new DataView(bytes.buffer).setUint32(0, length, true);
+  bytes.set(stringBytes, 4);
+  let B = Bytes(4 + length);
   let fields = toFieldsPacked(B, B.from(bytes));
-  return Poseidon.hash([Field(length), Field(0), ...fields]);
+  // console.log({ hashString: fields.map((x) => x.toBigInt()), bytes });
+  return Poseidon.hash(fields);
 }
 
 function packStringToField(string: string) {

--- a/src/credentials/dynamic-hash.ts
+++ b/src/credentials/dynamic-hash.ts
@@ -49,7 +49,12 @@ type HashableValue =
   | HashableValue[]
   | { [key in string]: HashableValue };
 
-function hashDynamic(value: HashableValue) {
+/**
+ * Hash an input that is either a simple JSON-with-bigints object or a provable type.
+ *
+ * The hashing algorithm is compatible with dynamic-length schemas.
+ */
+function hashDynamic(value: HashableValue | unknown) {
   return packToField(value, undefined, { mustHash: true });
 }
 
@@ -75,7 +80,7 @@ function packToField<T>(
   }
   // dynamic records
   if (value instanceof BaseType.GenericRecord.Base) {
-    return hashRecord(value);
+    return value.hash();
   }
 
   // now let's simply try to get the type from the value
@@ -109,7 +114,6 @@ function hashArray(array: unknown[]) {
 }
 
 function hashRecord(data: unknown) {
-  if (data instanceof BaseType.GenericRecord.Base) return data.hash();
   assert(
     typeof data === 'object' && data !== null,
     'Expected DynamicRecord or plain object as data'

--- a/src/credentials/dynamic-hash.ts
+++ b/src/credentials/dynamic-hash.ts
@@ -10,6 +10,7 @@ import {
 import { assert, hasProperty, mapEntries } from '../util.ts';
 import { NestedProvable } from '../nested.ts';
 import { GenericRecord, type UnknownRecord } from './dynamic-record.ts';
+import { DynamicArray } from './dynamic-array.ts';
 
 export {
   hashString,
@@ -48,9 +49,13 @@ function packStringToField(string: string) {
 function packToField<T>(type: ProvableType<T> | undefined, value: T): Field {
   type ??= NestedProvable.get(NestedProvable.fromValue(value));
 
-  // identify "record" types
+  // record types
   if (isStruct(type) || value instanceof GenericRecord.Base) {
     return hashRecord(value);
+  }
+  // dynamic array types
+  if (value instanceof DynamicArray.Base) {
+    return value.hash();
   }
   let fields = toFieldsPacked(type, value);
   if (fields.length === 1) return fields[0]!;

--- a/src/credentials/dynamic-hash.ts
+++ b/src/credentials/dynamic-hash.ts
@@ -46,7 +46,7 @@ function packStringToField(string: string) {
   return Poseidon.hash(fields);
 }
 
-function packToField<T>(type: ProvableType<T> | undefined, value: T): Field {
+function packToField<T>(value: T, type?: ProvableType<T>): Field {
   type ??= NestedProvable.get(NestedProvable.fromValue(value));
 
   // record types
@@ -70,7 +70,7 @@ function hashRecord(data: unknown) {
   );
   let entryHashes = mapEntries(data as UnknownRecord, (key, value) => {
     let type = NestedProvable.get(NestedProvable.fromValue(value));
-    return [packStringToField(key), packToField(type, value)];
+    return [packStringToField(key), packToField(value, type)];
   });
   return Poseidon.hash(entryHashes.flat());
 }

--- a/src/credentials/dynamic-hash.ts
+++ b/src/credentials/dynamic-hash.ts
@@ -54,7 +54,9 @@ function hashDynamic(value: HashableValue) {
 
 const simpleTypes = new Set(['number', 'boolean', 'bigint', 'undefined']);
 
-function isSimple(value: HashableValue) {
+function isSimple(
+  value: unknown
+): value is number | boolean | bigint | undefined {
   return simpleTypes.has(typeof value);
 }
 
@@ -94,7 +96,6 @@ function innerArrayType(array: HashableValue[]): ProvableHashableType {
   let type = provableTypeOf(array[0]);
   assert(
     array.every((v) => {
-      console.log(v, type, provableTypeOf(v));
       return provableTypeEquals(v, type);
     }),
     'Array elements must be homogenous'
@@ -106,7 +107,8 @@ function hashArray(array: HashableValue[]) {
   let type = innerArrayType(array);
   let Array = BaseType.DynamicArray(type, { maxLength: array.length });
   let as = Array.from(array);
-  console.log(as);
+  // TODO remove
+  console.dir(as, { depth: 4 });
   return as.hash();
 }
 
@@ -133,6 +135,11 @@ function packStringToField(string: string) {
 }
 
 function packToField<T>(value: T, type?: ProvableType<T>): Field {
+  // hashable values
+  if (isSimple(value) || typeof value === 'string' || Array.isArray(value)) {
+    return hashDynamic(value);
+  }
+
   // dynamic array types
   if (value instanceof BaseType.DynamicArray.Base) {
     return value.hash();

--- a/src/credentials/dynamic-hash.ts
+++ b/src/credentials/dynamic-hash.ts
@@ -1,18 +1,29 @@
 /**
  * Hashing of arbitrary data types compatible with dynamic-length schemas.
  */
-import { Bytes, Field, Poseidon, Struct, UInt8 } from 'o1js';
+import {
+  Bool,
+  Bytes,
+  Field,
+  Poseidon,
+  Struct,
+  UInt64,
+  UInt8,
+  Undefined,
+} from 'o1js';
 import {
   type ProvableHashableType,
   ProvableType,
   toFieldsPacked,
 } from '../o1js-missing.ts';
-import { assert, hasProperty, mapEntries } from '../util.ts';
+import { assert, hasProperty, isSubclass, mapEntries } from '../util.ts';
 import { NestedProvable } from '../nested.ts';
-import { GenericRecord, type UnknownRecord } from './dynamic-record.ts';
-import { DynamicArray } from './dynamic-array.ts';
+import type { UnknownRecord } from './dynamic-record.ts';
+import { BaseType } from './dynamic-base-types.ts';
 
 export {
+  hashDynamic,
+  hashArray,
   hashString,
   packStringToField,
   packToField,
@@ -22,6 +33,82 @@ export {
 };
 
 // compatible hashing
+
+type HashableValue =
+  | undefined
+  | string
+  | number
+  | boolean
+  | bigint
+  | HashableValue[]
+  | { [key in string]: HashableValue };
+
+function hashDynamic(value: HashableValue) {
+  if (typeof value === 'string') return hashString(value);
+  if (typeof value === 'number') return packToField(UInt64.from(value), UInt64);
+  if (typeof value === 'boolean') return packToField(Bool(value), Bool);
+  if (typeof value === 'bigint') return packToField(Field(value), Field);
+  if (Array.isArray(value)) return hashArray(value);
+  return hashRecord(value);
+}
+
+const simpleTypes = new Set(['number', 'boolean', 'bigint', 'undefined']);
+
+function isSimple(value: HashableValue) {
+  return simpleTypes.has(typeof value);
+}
+
+function provableTypeOf(value: HashableValue): ProvableHashableType {
+  if (value === undefined) return Undefined;
+  if (typeof value === 'string') {
+    return BaseType.DynamicString({ maxLength: value.length });
+  }
+  if (typeof value === 'number') return UInt64;
+  if (typeof value === 'boolean') return Bool;
+  if (typeof value === 'bigint') return Field;
+  if (Array.isArray(value)) {
+    return BaseType.DynamicArray(innerArrayType(value), {
+      maxLength: value.length,
+    });
+  }
+  return BaseType.DynamicRecord({}, { maxEntries: Object.keys(value).length });
+}
+
+function provableTypeEquals(
+  value: HashableValue,
+  type: ProvableHashableType
+): boolean {
+  if (isSimple(value)) return provableTypeOf(value) === type;
+  if (typeof value === 'string') {
+    return isSubclass(type, BaseType.DynamicString.Base);
+  }
+  if (Array.isArray(value)) {
+    if (!isSubclass(type, BaseType.DynamicArray.Base)) return false;
+    let innerType = type.prototype.innerType;
+    return value.every((v) => provableTypeEquals(v, innerType));
+  }
+  return isSubclass(type, BaseType.GenericRecord.Base);
+}
+
+function innerArrayType(array: HashableValue[]): ProvableHashableType {
+  let type = provableTypeOf(array[0]);
+  assert(
+    array.every((v) => {
+      console.log(v, type, provableTypeOf(v));
+      return provableTypeEquals(v, type);
+    }),
+    'Array elements must be homogenous'
+  );
+  return type;
+}
+
+function hashArray(array: HashableValue[]) {
+  let type = innerArrayType(array);
+  let Array = BaseType.DynamicArray(type, { maxLength: array.length });
+  let as = Array.from(array);
+  console.log(as);
+  return as.hash();
+}
 
 const enc = new TextEncoder();
 
@@ -34,7 +121,6 @@ function hashString(string: string) {
   bytes.set(stringBytes, 4);
   let B = Bytes(4 + length);
   let fields = toFieldsPacked(B, B.from(bytes));
-  // console.log({ hashString: fields.map((x) => x.toBigInt()), bytes });
   return Poseidon.hash(fields);
 }
 
@@ -47,23 +133,25 @@ function packStringToField(string: string) {
 }
 
 function packToField<T>(value: T, type?: ProvableType<T>): Field {
+  // dynamic array types
+  if (value instanceof BaseType.DynamicArray.Base) {
+    return value.hash();
+  }
+
   type ??= NestedProvable.get(NestedProvable.fromValue(value));
 
   // record types
-  if (isStruct(type) || value instanceof GenericRecord.Base) {
+  if (isStruct(type) || value instanceof BaseType.GenericRecord.Base) {
     return hashRecord(value);
   }
-  // dynamic array types
-  if (value instanceof DynamicArray.Base) {
-    return value.hash();
-  }
+
   let fields = toFieldsPacked(type, value);
   if (fields.length === 1) return fields[0]!;
   return Poseidon.hash(fields);
 }
 
 function hashRecord(data: unknown) {
-  if (data instanceof GenericRecord.Base) return data.hash();
+  if (data instanceof BaseType.GenericRecord.Base) return data.hash();
   assert(
     typeof data === 'object' && data !== null,
     'Expected DynamicRecord or plain object as data'

--- a/src/credentials/dynamic-hash.ts
+++ b/src/credentials/dynamic-hash.ts
@@ -1,25 +1,49 @@
 /**
  * Hashing of arbitrary data types compatible with dynamic-length schemas.
  */
-import { Bytes, Field, Poseidon, Struct } from 'o1js';
-import { ProvableType, toFieldsPacked } from '../o1js-missing.ts';
+import { Bytes, Field, Poseidon, Struct, UInt8 } from 'o1js';
+import {
+  type ProvableHashableType,
+  ProvableType,
+  toFieldsPacked,
+} from '../o1js-missing.ts';
 import { assert, hasProperty, mapEntries } from '../util.ts';
 import { NestedProvable } from '../nested.ts';
 import { GenericRecord, type UnknownRecord } from './dynamic-record.ts';
 
-export { packStringToField, packToField, hashRecord };
+export {
+  hashString,
+  packStringToField,
+  packToField,
+  hashRecord,
+  bitSize,
+  packedFieldSize,
+};
 
 // compatible hashing
 
+const enc = new TextEncoder();
+
+function hashString(string: string) {
+  // encode length + bytes
+  let bytes = enc.encode(string);
+  let length = bytes.length;
+  let B = Bytes(length);
+  let fields = toFieldsPacked(B, B.from(bytes));
+  return Poseidon.hash([Field(length), Field(0), ...fields]);
+}
+
 function packStringToField(string: string) {
-  let bytes = new TextEncoder().encode(string);
+  let bytes = enc.encode(string);
   let B = Bytes(bytes.length);
   let fields = toFieldsPacked(B, B.from(bytes));
   if (fields.length === 1) return fields[0]!;
   return Poseidon.hash(fields);
 }
 
-function packToField<T>(type: ProvableType<T>, value: T): Field {
+function packToField<T>(type: ProvableType<T> | undefined, value: T): Field {
+  type ??= NestedProvable.get(NestedProvable.fromValue(value));
+
   // identify "record" types
   if (isStruct(type) || value instanceof GenericRecord.Base) {
     return hashRecord(value);
@@ -42,6 +66,39 @@ function hashRecord(data: unknown) {
   return Poseidon.hash(entryHashes.flat());
 }
 
+// helpers
+
 function isStruct(type: ProvableType): type is Struct<any> {
-  return hasProperty(type, '_isStruct') && type._isStruct === true;
+  return (
+    hasProperty(type, '_isStruct') &&
+    type._isStruct === true &&
+    // this shouldn't have been implemented as struct, it's just 1 field
+    type !== UInt8
+  );
+}
+
+function bitSize(type: ProvableHashableType): number {
+  let provable = ProvableType.get(type);
+  let { fields = [], packed = [] } = provable.toInput(provable.empty());
+  let nBits = fields.length * Field.sizeInBits;
+  for (let [, size] of packed) {
+    nBits += size;
+  }
+  return nBits;
+}
+
+function packedFieldSize(type: ProvableHashableType): number {
+  let provable = ProvableType.get(type);
+  let { fields = [], packed = [] } = provable.toInput(provable.empty());
+  let nFields = fields.length;
+  let pendingBits = 0;
+  for (let [, size] of packed) {
+    pendingBits += size;
+    if (pendingBits >= Field.sizeInBits) {
+      nFields++;
+      pendingBits -= Field.sizeInBits;
+    }
+  }
+  if (pendingBits > 0) nFields++;
+  return nFields;
 }

--- a/src/credentials/dynamic-hash.ts
+++ b/src/credentials/dynamic-hash.ts
@@ -16,7 +16,13 @@ import {
   ProvableType,
   toFieldsPacked,
 } from '../o1js-missing.ts';
-import { assert, hasProperty, isSubclass, mapEntries } from '../util.ts';
+import {
+  assert,
+  hasProperty,
+  isSubclass,
+  mapEntries,
+  stringLength,
+} from '../util.ts';
 import { NestedProvable } from '../nested.ts';
 import type { UnknownRecord } from './dynamic-record.ts';
 import { BaseType } from './dynamic-base-types.ts';
@@ -63,7 +69,7 @@ function isSimple(
 function provableTypeOf(value: HashableValue): ProvableHashableType {
   if (value === undefined) return Undefined;
   if (typeof value === 'string') {
-    return BaseType.DynamicString({ maxLength: value.length });
+    return BaseType.DynamicString({ maxLength: stringLength(value) });
   }
   if (typeof value === 'number') return UInt64;
   if (typeof value === 'boolean') return Bool;
@@ -106,10 +112,7 @@ function innerArrayType(array: HashableValue[]): ProvableHashableType {
 function hashArray(array: HashableValue[]) {
   let type = innerArrayType(array);
   let Array = BaseType.DynamicArray(type, { maxLength: array.length });
-  let as = Array.from(array);
-  // TODO remove
-  console.dir(as, { depth: 4 });
-  return as.hash();
+  return Array.from(array).hash();
 }
 
 const enc = new TextEncoder();

--- a/src/credentials/dynamic-hash.ts
+++ b/src/credentials/dynamic-hash.ts
@@ -1,0 +1,47 @@
+/**
+ * Hashing of arbitrary data types compatible with dynamic-length schemas.
+ */
+import { Bytes, Field, Poseidon, Struct } from 'o1js';
+import { ProvableType, toFieldsPacked } from '../o1js-missing.ts';
+import { assert, hasProperty, mapEntries } from '../util.ts';
+import { NestedProvable } from '../nested.ts';
+import { GenericRecord, type UnknownRecord } from './dynamic-record.ts';
+
+export { packStringToField, packToField, hashRecord };
+
+// compatible hashing
+
+function packStringToField(string: string) {
+  let bytes = new TextEncoder().encode(string);
+  let B = Bytes(bytes.length);
+  let fields = toFieldsPacked(B, B.from(bytes));
+  if (fields.length === 1) return fields[0]!;
+  return Poseidon.hash(fields);
+}
+
+function packToField<T>(type: ProvableType<T>, value: T): Field {
+  // identify "record" types
+  if (isStruct(type) || value instanceof GenericRecord.Base) {
+    return hashRecord(value);
+  }
+  let fields = toFieldsPacked(type, value);
+  if (fields.length === 1) return fields[0]!;
+  return Poseidon.hash(fields);
+}
+
+function hashRecord(data: unknown) {
+  if (data instanceof GenericRecord.Base) return data.hash();
+  assert(
+    typeof data === 'object' && data !== null,
+    'Expected DynamicRecord or plain object as data'
+  );
+  let entryHashes = mapEntries(data as UnknownRecord, (key, value) => {
+    let type = NestedProvable.get(NestedProvable.fromValue(value));
+    return [packStringToField(key), packToField(type, value)];
+  });
+  return Poseidon.hash(entryHashes.flat());
+}
+
+function isStruct(type: ProvableType): type is Struct<any> {
+  return hasProperty(type, '_isStruct') && type._isStruct === true;
+}

--- a/src/credentials/dynamic-record.test.ts
+++ b/src/credentials/dynamic-record.test.ts
@@ -16,7 +16,7 @@ import { test } from 'node:test';
 import assert from 'assert';
 import { hashCredential } from '../credential.ts';
 import { owner } from '../../tests/test-utils.ts';
-import { hashRecord } from './dynamic-hash.ts';
+import { hashDynamic, hashRecord } from './dynamic-hash.ts';
 import { array } from '../o1js-missing.ts';
 import { DynamicArray } from './dynamic-array.ts';
 
@@ -121,9 +121,10 @@ async function circuit() {
   await test('DynamicRecord.hash()', () =>
     record.hash().assertEquals(expectedHash, 'hash'));
 
-  await test('hashRecord()', () => {
-    hashRecord(originalStruct).assertEquals(expectedHash);
-    hashRecord(record).assertEquals(expectedHash);
+  await test('hashDynamic()', () => {
+    hashDynamic(original).assertEquals(expectedHash);
+    hashDynamic(originalStruct).assertEquals(expectedHash);
+    hashDynamic(record).assertEquals(expectedHash);
   });
 
   await test('hashCredential()', () => {

--- a/src/credentials/dynamic-record.test.ts
+++ b/src/credentials/dynamic-record.test.ts
@@ -17,6 +17,8 @@ import assert from 'assert';
 import { hashCredential } from '../credential.ts';
 import { owner } from '../../tests/test-utils.ts';
 import { hashRecord } from './dynamic-hash.ts';
+import { array } from '../o1js-missing.ts';
+import { DynamicArray } from './dynamic-array.ts';
 
 const String10 = DynamicString({ maxLength: 10 });
 
@@ -28,6 +30,7 @@ const OriginalSchema = Schema({
   third: String10,
   fourth: UInt64,
   fifth: { field: Field, string: String10 },
+  sixth: array(Field, 3),
 });
 
 let input = {
@@ -36,6 +39,7 @@ let input = {
   third: 'something',
   fourth: 123n,
   fifth: { field: 2, string: '...' },
+  sixth: [1n, 2n, 3n],
 };
 
 let original = OriginalSchema.from(input);
@@ -102,6 +106,13 @@ async function circuit() {
       FifthStruct,
       record.getAny(FifthStruct, 'fifth'),
       FifthStruct.fromValue({ field: 2, string: '...' })
+    );
+
+    const SixthDynamic = DynamicArray(Field, { maxLength: 7 });
+    Provable.assertEqual(
+      SixthDynamic,
+      record.getAny(SixthDynamic, 'sixth'),
+      SixthDynamic.from([1n, 2n, 3n])
     );
 
     assert.throws(() => record.getAny(Bool, 'missing'), /Key not found/);

--- a/src/credentials/dynamic-record.test.ts
+++ b/src/credentials/dynamic-record.test.ts
@@ -52,16 +52,8 @@ let originalStruct = OriginalWrappedInStruct.fromValue(input);
 // subset schema and circuit that doesn't know the full original layout
 
 const Fifth = DynamicRecord(
-  { field: Field, string: DynamicString({ maxLength: 5 }) },
+  { field: Field, string: String },
   { maxEntries: 5 }
-);
-
-// TODO fix this not being all equal
-zip(
-  Fifth.provable.toFields(Fifth.from({ field: 2, string: '...' })),
-  Fifth.provable.toFields(Fifth.from({ field: 2, string: String.from('...') }))
-).map(([a, b], i) =>
-  console.log(a.toBigInt(), b.toBigInt(), a.equals(b).toBoolean())
 );
 
 const Subschema = DynamicRecord(
@@ -88,7 +80,7 @@ async function circuit() {
     Provable.assertEqual(
       Fifth,
       record.get('fifth'),
-      Fifth.from({ field: 2, string: String.from('...') })
+      Fifth.from({ field: 2, string: '...' })
     );
   });
 

--- a/src/credentials/dynamic-record.ts
+++ b/src/credentials/dynamic-record.ts
@@ -94,7 +94,7 @@ function DynamicRecord<
               type === undefined ? value : type.fromValue(value);
             return {
               key: packStringToField(key).toBigInt(),
-              value: packToField(type, actualValue).toBigInt(),
+              value: packToField(actualValue, type).toBigInt(),
             };
           });
           return { entries: pad(entries, maxEntries, undefined), actual };
@@ -146,7 +146,7 @@ class GenericRecordBase {
       let type = NestedProvable.get(NestedProvable.fromValue(value));
       return {
         key: packStringToField(key),
-        value: packToField(type, type.fromValue(value)),
+        value: packToField(type.fromValue(value), type),
       };
     });
     let options = pad(
@@ -176,7 +176,7 @@ class GenericRecordBase {
     );
 
     // assert that value matches hash, and return it
-    packToField(valueType, value).assertEquals(
+    packToField(value, valueType).assertEquals(
       valueHash,
       `Bug: Invalid value for key "${key}"`
     );

--- a/src/credentials/dynamic-record.ts
+++ b/src/credentials/dynamic-record.ts
@@ -96,13 +96,7 @@ function DynamicRecord<
           // validate that `actual` (at least) contains all known keys
           assertExtendsShape(actual, knownShape);
 
-          let actual_ = actual; //mapObject(actual, (value, key) => {
-          //   return key in shape
-          //     ? ProvableType.get(shape[key]).fromValue(value)
-          //     : value;
-          // });
-
-          let entries = Object.entries<unknown>(actual_).map(([key, value]) => {
+          let entries = Object.entries<unknown>(actual).map(([key, value]) => {
             let type = NestedProvable.get(
               key in knownShape
                 ? (knownShape[key] as any)
@@ -113,10 +107,7 @@ function DynamicRecord<
               value: packToField(type, type.fromValue(value)).toBigInt(),
             };
           });
-          return {
-            entries: pad(entries, maxEntries, undefined),
-            actual: actual_,
-          };
+          return { entries: pad(entries, maxEntries, undefined), actual };
         },
         distinguish(x) {
           return x instanceof DynamicRecordBase;

--- a/src/credentials/dynamic-record.ts
+++ b/src/credentials/dynamic-record.ts
@@ -32,7 +32,7 @@ import {
   serializeNestedProvable,
   serializeNestedProvableValue,
 } from '../serialize-provable.ts';
-import { packStringToField, packToField } from './dynamic-hash.ts';
+import { hashString, packToField } from './dynamic-hash.ts';
 import { BaseType } from './dynamic-base-types.ts';
 
 export { DynamicRecord, GenericRecord, type UnknownRecord, extractProperty };
@@ -94,7 +94,7 @@ function DynamicRecord<
             let actualValue =
               type === undefined ? value : type.fromValue(value);
             return {
-              key: packStringToField(key).toBigInt(),
+              key: hashString(key).toBigInt(),
               value: packToField(actualValue, type).toBigInt(),
             };
           });
@@ -148,7 +148,7 @@ class GenericRecordBase {
     let entries = Object.entries<unknown>(actual).map(([key, value]) => {
       let type = NestedProvable.get(NestedProvable.fromValue(value));
       return {
-        key: packStringToField(key),
+        key: hashString(key),
         value: packToField(type.fromValue(value), type),
       };
     });
@@ -162,7 +162,7 @@ class GenericRecordBase {
 
   getAny<A extends ProvableHashableType>(valueType: A, key: string) {
     // find valueHash for key
-    let keyHash = packStringToField(key);
+    let keyHash = hashString(key);
     let current = OptionField.none();
 
     for (let { isSome, value: entry } of this.entries) {

--- a/src/credentials/dynamic-record.ts
+++ b/src/credentials/dynamic-record.ts
@@ -207,7 +207,7 @@ class GenericRecordBase {
   }
 }
 
-BaseType.set('GenericRecord', GenericRecord);
+BaseType.GenericRecord = GenericRecord;
 GenericRecord.Base = GenericRecordBase;
 
 class DynamicRecordBase<TKnown = any> extends GenericRecordBase {
@@ -223,7 +223,7 @@ class DynamicRecordBase<TKnown = any> extends GenericRecordBase {
   }
 }
 
-BaseType.set('DynamicRecord', DynamicRecord);
+BaseType.DynamicRecord = DynamicRecord;
 DynamicRecord.Base = DynamicRecordBase;
 
 type DynamicRecordRaw = {

--- a/src/credentials/dynamic-record.ts
+++ b/src/credentials/dynamic-record.ts
@@ -160,7 +160,7 @@ class GenericRecordBase {
     return new this({ entries: options, actual: Unconstrained.from(actual) });
   }
 
-  getAny<A extends ProvableType>(valueType: A, key: string) {
+  getAny<A extends ProvableHashableType>(valueType: A, key: string) {
     // find valueHash for key
     let keyHash = packStringToField(key);
     let current = OptionField.none();

--- a/src/credentials/dynamic-record.ts
+++ b/src/credentials/dynamic-record.ts
@@ -33,6 +33,7 @@ import {
   serializeNestedProvableValue,
 } from '../serialize-provable.ts';
 import { packStringToField, packToField } from './dynamic-hash.ts';
+import { BaseType } from './dynamic-base-types.ts';
 
 export { DynamicRecord, GenericRecord, type UnknownRecord, extractProperty };
 
@@ -113,6 +114,7 @@ function DynamicRecord<
     }
   };
 }
+BaseType.set('DynamicRecord', DynamicRecord);
 
 const OptionField = Option(Field);
 const OptionKeyValue = Option(Struct({ key: Field, value: Field }));
@@ -127,6 +129,7 @@ function GenericRecord({ maxEntries }: { maxEntries: number }) {
     }
   };
 }
+BaseType.set('GenericRecord', GenericRecord);
 
 class GenericRecordBase {
   entries: Option<{ key: Field; value: Field }>[];

--- a/src/credentials/dynamic-record.ts
+++ b/src/credentials/dynamic-record.ts
@@ -73,6 +73,12 @@ function DynamicRecord<
       return DynamicRecord.provable.fromValue(actual);
     }
 
+    static get shape(): {
+      [K in keyof TKnown]: ProvableHashableType<TKnown[K]>;
+    } {
+      return shape;
+    }
+
     static provable = TypeBuilder.shape({
       entries: array(Option(Struct({ key: Field, value: Field })), maxEntries),
       actual: Unconstrained.withEmpty<UnknownRecord>(emptyTKnown),
@@ -114,7 +120,6 @@ function DynamicRecord<
     }
   };
 }
-BaseType.set('DynamicRecord', DynamicRecord);
 
 const OptionField = Option(Field);
 const OptionKeyValue = Option(Struct({ key: Field, value: Field }));
@@ -129,7 +134,6 @@ function GenericRecord({ maxEntries }: { maxEntries: number }) {
     }
   };
 }
-BaseType.set('GenericRecord', GenericRecord);
 
 class GenericRecordBase {
   entries: Option<{ key: Field; value: Field }>[];
@@ -203,6 +207,7 @@ class GenericRecordBase {
   }
 }
 
+BaseType.set('GenericRecord', GenericRecord);
 GenericRecord.Base = GenericRecordBase;
 
 class DynamicRecordBase<TKnown = any> extends GenericRecordBase {
@@ -218,6 +223,7 @@ class DynamicRecordBase<TKnown = any> extends GenericRecordBase {
   }
 }
 
+BaseType.set('DynamicRecord', DynamicRecord);
 DynamicRecord.Base = DynamicRecordBase;
 
 type DynamicRecordRaw = {

--- a/src/credentials/dynamic-record.ts
+++ b/src/credentials/dynamic-record.ts
@@ -86,14 +86,15 @@ function DynamicRecord<
           assertExtendsShape(actual, knownShape);
 
           let entries = Object.entries<unknown>(actual).map(([key, value]) => {
-            let type = NestedProvable.get(
+            let type =
               key in knownShape
-                ? (knownShape[key] as any)
-                : NestedProvable.fromValue(value)
-            );
+                ? NestedProvable.get(knownShape[key]!)
+                : undefined;
+            let actualValue =
+              type === undefined ? value : type.fromValue(value);
             return {
               key: packStringToField(key).toBigInt(),
-              value: packToField(type, type.fromValue(value)).toBigInt(),
+              value: packToField(type, actualValue).toBigInt(),
             };
           });
           return { entries: pad(entries, maxEntries, undefined), actual };

--- a/src/credentials/dynamic-record.ts
+++ b/src/credentials/dynamic-record.ts
@@ -149,19 +149,15 @@ class GenericRecordBase {
   }
 
   static from(actual: UnknownRecord): GenericRecordBase {
-    let entries = Object.entries<unknown>(actual).map(([key, value]) => {
-      let type = NestedProvable.get(NestedProvable.fromValue(value));
-      return {
+    let entries = Object.entries(actual).map(([key, value]) => {
+      return OptionKeyValue.from({
         key: hashString(key),
-        value: packToField(type.fromValue(value), type),
-      };
+        value: packToField(value),
+      });
     });
-    let options = pad(
-      entries.map((entry) => OptionKeyValue.from(entry)),
-      this.prototype.maxEntries,
-      OptionKeyValue.none()
-    );
-    return new this({ entries: options, actual: Unconstrained.from(actual) });
+    let maxEntries = this.prototype.maxEntries;
+    let padded = pad(entries, maxEntries, OptionKeyValue.none());
+    return new this({ entries: padded, actual: Unconstrained.from(actual) });
   }
 
   getAny<A extends ProvableHashableType>(valueType: A, key: string) {

--- a/src/credentials/dynamic-string.ts
+++ b/src/credentials/dynamic-string.ts
@@ -47,10 +47,14 @@ function DynamicString({ maxLength }: { maxLength: number }) {
       there(s) {
         return dec.decode(Uint8Array.from(s, ({ value }) => Number(value)));
       },
-      back(s) {
+      backAndDistinguish(s) {
+        // gracefully handle different maxLength
+        if (s instanceof DynamicStringBase) {
+          if (s.maxLength === maxLength) return s;
+          s = s.toString();
+        }
         return [...enc.encode(s)].map((t) => ({ value: BigInt(t) }));
       },
-      distinguish: (s) => s instanceof DynamicStringBase,
     })
     .build();
 

--- a/src/credentials/dynamic-string.ts
+++ b/src/credentials/dynamic-string.ts
@@ -34,7 +34,7 @@ function DynamicString({ maxLength }: { maxLength: number }) {
     /**
      * Create DynamicBytes from a string.
      */
-    static from(s: string) {
+    static from(s: string | DynamicStringBase) {
       return provableString.fromValue(s);
     }
   }

--- a/src/credentials/dynamic-string.ts
+++ b/src/credentials/dynamic-string.ts
@@ -2,6 +2,7 @@ import { Bool, Field, type ProvableHashable, UInt8 } from 'o1js';
 import { DynamicArrayBase, provableDynamicArray } from './dynamic-array.ts';
 import { ProvableFactory } from '../provable-factory.ts';
 import { assert } from '../util.ts';
+import { BaseType } from './dynamic-base-types.ts';
 
 export { DynamicString };
 
@@ -60,6 +61,7 @@ function DynamicString({ maxLength }: { maxLength: number }) {
 
   return DynamicString;
 }
+BaseType.set('DynamicString', DynamicString);
 
 const enc = new TextEncoder();
 const dec = new TextDecoder();

--- a/src/credentials/dynamic-string.ts
+++ b/src/credentials/dynamic-string.ts
@@ -1,4 +1,4 @@
-import { Bool, Field, Provable, UInt8 } from 'o1js';
+import { Bool, Field, type ProvableHashable, UInt8 } from 'o1js';
 import { DynamicArrayBase, provableDynamicArray } from './dynamic-array.ts';
 import { ProvableFactory } from '../provable-factory.ts';
 import { assert } from '../util.ts';
@@ -62,7 +62,7 @@ const dec = new TextDecoder();
 
 class DynamicStringBase extends DynamicArrayBase<UInt8, { value: bigint }> {
   get innerType() {
-    return UInt8 as any as Provable<UInt8, { value: bigint }>;
+    return UInt8 as any as ProvableHashable<UInt8, { value: bigint }>;
   }
 
   /**

--- a/src/credentials/dynamic-string.ts
+++ b/src/credentials/dynamic-string.ts
@@ -63,7 +63,7 @@ function DynamicString({ maxLength }: { maxLength: number }) {
 
   return DynamicString;
 }
-BaseType.set('DynamicString', DynamicString);
+BaseType.DynamicString = DynamicString;
 
 const enc = new TextEncoder();
 const dec = new TextDecoder();

--- a/src/credentials/gadgets.ts
+++ b/src/credentials/gadgets.ts
@@ -4,7 +4,26 @@
 import { Bool, Field, Gadgets, Provable, UInt32 } from 'o1js';
 import { assert } from '../util.ts';
 
-export { unsafeIf, seal, lessThan16, assertInRange16, assertLessThan16 };
+export { pack, unsafeIf, seal, lessThan16, assertInRange16, assertLessThan16 };
+
+/**
+ * Pack a list of fields of bit size `chunkSize` each into a single field.
+ * Uses little-endian encoding.
+ *
+ * **Warning**: Assumes, but doesn't prove, that each chunk fits in the chunk size.
+ */
+function pack(chunks: Field[], chunkSize: number) {
+  let p = chunks.length * chunkSize;
+  assert(
+    p < Field.sizeInBits,
+    () => `pack(): too many chunks, got ${chunks.length} * ${chunkSize} = ${p}`
+  );
+  let sum = Field(0);
+  chunks.forEach((chunk, i) => {
+    sum = sum.add(chunk.mul(1n << BigInt(i * chunkSize)));
+  });
+  return sum.seal();
+}
 
 /**
  * Slightly more efficient version of Provable.if() which produces garbage if both t is a non-dummy and b is true.

--- a/src/credentials/gadgets.ts
+++ b/src/credentials/gadgets.ts
@@ -15,7 +15,7 @@ export { pack, unsafeIf, seal, lessThan16, assertInRange16, assertLessThan16 };
 function pack(chunks: Field[], chunkSize: number) {
   let p = chunks.length * chunkSize;
   assert(
-    p < Field.sizeInBits,
+    chunks.length <= 1 || p < Field.sizeInBits,
     () => `pack(): too many chunks, got ${chunks.length} * ${chunkSize} = ${p}`
   );
   let sum = Field(0);

--- a/src/credentials/static-array.ts
+++ b/src/credentials/static-array.ts
@@ -9,7 +9,7 @@ import {
   Gadgets,
   type ProvableHashable,
 } from 'o1js';
-import { assert, chunk, zip } from '../util.ts';
+import { assert, assertHasProperty, chunk, zip } from '../util.ts';
 import { ProvableType } from '../o1js-missing.ts';
 import { assertLessThan16, lessThan16 } from './gadgets.ts';
 import { TypeBuilder } from '../provable-type-builder.ts';
@@ -124,6 +124,8 @@ class StaticArrayBase<T = any, V = any> {
 
   /**
    * Gets value at index i, and proves that the index is in the array.
+   *
+   * Handles constant indices without creating constraints.
    *
    * Cost: TN + 1.5
    */
@@ -276,9 +278,8 @@ class StaticArrayBase<T = any, V = any> {
   }
 
   toValue() {
-    return (
-      this.constructor as any as { provable: Provable<any, V[]> }
-    ).provable.toValue(this);
+    assertHasProperty(this.constructor, 'provable', 'Need subclass');
+    return (this.constructor.provable as Provable<this, V[]>).toValue(this);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,6 @@ export { DynamicArray } from './credentials/dynamic-array.ts';
 export { StaticArray } from './credentials/static-array.ts';
 export { DynamicBytes } from './credentials/dynamic-bytes.ts';
 export { DynamicString } from './credentials/dynamic-string.ts';
+export { hashPacked } from './o1js-missing.ts';
 
 export type { InferProvable as InferSchema } from 'o1js';

--- a/src/nested.ts
+++ b/src/nested.ts
@@ -2,8 +2,18 @@
  * Allows us to represent nested Provable types, to save us from always having to
  * wrap types in `Struct` and similar.
  */
-import { type InferProvable, Provable, type ProvablePure, Struct } from 'o1js';
-import { array, type ProvablePureType, ProvableType } from './o1js-missing.ts';
+import {
+  type InferProvable,
+  Provable,
+  type ProvableHashable,
+  Struct,
+} from 'o1js';
+import {
+  array,
+  type ProvableHashablePure,
+  type ProvablePureType,
+  ProvableType,
+} from './o1js-missing.ts';
 import { assertIsObject } from './util.ts';
 
 export { NestedProvable };
@@ -15,18 +25,16 @@ export type {
   InferNestedProvable,
 };
 
-// TODO!! NestedProvable should include Hashable type as well
-
 const NestedProvable = {
   get: (<T>(type: NestedProvableFor<T>): Provable<T> => {
     return ProvableType.isProvableType(type)
       ? ProvableType.get(type)
       : Struct(type);
   }) as {
-    <T>(type: NestedProvablePureFor<T>): ProvablePure<T>;
-    <T>(type: NestedProvableFor<T>): Provable<T>;
-    (type: NestedProvablePure): ProvablePure<any>;
-    (type: NestedProvable): Provable<any>;
+    <T>(type: NestedProvablePureFor<T>): ProvableHashablePure<T>;
+    <T>(type: NestedProvableFor<T>): ProvableHashable<T>;
+    (type: NestedProvablePure): ProvableHashablePure;
+    (type: NestedProvable): ProvableHashable<any>;
   },
 
   fromValue<T>(value: T): NestedProvableFor<T> {
@@ -50,6 +58,8 @@ const NestedProvable = {
     }
   },
 };
+
+// TODO!! NestedProvable should accurately requre hashable type
 
 type NestedProvable = ProvableType | { [key: string]: NestedProvable };
 type NestedProvablePure =

--- a/src/o1js-missing.ts
+++ b/src/o1js-missing.ts
@@ -35,11 +35,7 @@ export {
 const ProvableType = {
   get<A extends WithProvable<any>>(type: A): ToProvable<A> {
     return (
-      (typeof type === 'object' || typeof type === 'function') &&
-      type !== null &&
-      'provable' in type
-        ? type.provable
-        : type
+      hasProperty(type, 'provable') ? type.provable : type
     ) as ToProvable<A>;
   },
 
@@ -70,6 +66,15 @@ const ProvableType = {
   isProvableType(type: unknown): type is ProvableType {
     let type_ = ProvableType.get(type);
     return hasProperty(type_, 'toFields') && hasProperty(type_, 'fromFields');
+  },
+
+  isProvableHashableType(type: unknown): type is ProvableHashableType {
+    let type_ = ProvableType.get(type);
+    return (
+      ProvableType.isProvableType(type_) &&
+      hasProperty(type_, 'toInput') &&
+      hasProperty(type_, 'empty')
+    );
   },
 
   constant<T>(value: T): ProvablePure<T, T> & { serialize(): any } {
@@ -113,7 +118,9 @@ function lengthRecursive(array: NestedArray): number {
   return length;
 }
 
-function assertIsProvable(type: unknown): asserts type is Provable<any> {
+function assertIsProvable(
+  type: unknown
+): asserts type is ProvableMaybeHashable {
   assertHasProperty(
     type,
     'toFields',

--- a/src/o1js-missing.ts
+++ b/src/o1js-missing.ts
@@ -22,6 +22,7 @@ export {
   type ProvablePureType,
   type ProvableHashableType,
   type ProvableHashablePure,
+  type ProvableMaybeHashable,
   array,
   toFieldsPacked,
   HashInput,

--- a/src/o1js-missing.ts
+++ b/src/o1js-missing.ts
@@ -26,6 +26,8 @@ export {
   array,
   toFieldsPacked,
   hashPacked,
+  empty,
+  toInput,
   HashInput,
   type WithProvable,
 };

--- a/src/provable-factory.ts
+++ b/src/provable-factory.ts
@@ -52,33 +52,33 @@ const ProvableFactory = {
   },
 
   getRegistered(value: unknown) {
-    let key: string | undefined;
-    let factory: MapValue | undefined;
-    for (let [key_, factory_] of factories.entries()) {
-      if (value instanceof factory_.base) {
-        key = key_;
-        factory = factory_;
+    let entry: [string, MapValue] | undefined;
+    for (let [key, factory] of factories.entries()) {
+      if (value instanceof factory.base) {
+        entry = [key, factory];
       }
     }
-    return [key, factory] as const;
+    return entry;
   },
 
   tryToJSON(constructor: unknown): SerializedFactory | undefined {
     if (!hasProperty(constructor, 'prototype')) return undefined;
-    let [key, factory] = ProvableFactory.getRegistered(constructor.prototype);
-    if (factory === undefined) return undefined;
+    let entry = ProvableFactory.getRegistered(constructor.prototype);
+    if (entry === undefined) return undefined;
+    let [key, factory] = entry;
     let json = factory.typeToJSON(constructor as any);
-    return { _type: key!, ...json, _isFactory: true as const };
+    return { _type: key, ...json, _isFactory: true as const };
   },
 
   tryValueToJSON(
     value: unknown
   ): (SerializedFactory & { value: any }) | undefined {
-    let [key, factory] = ProvableFactory.getRegistered(value);
-    if (factory === undefined) return undefined;
+    let entry = ProvableFactory.getRegistered(value);
+    if (entry === undefined) return undefined;
+    let [key, factory] = entry;
     let serializedType = factory.typeToJSON(value!.constructor as any);
     return {
-      _type: key!,
+      _type: key,
       ...serializedType,
       value: factory.valueToJSON(value!.constructor as any, value),
       _isFactory: true as const,

--- a/src/provable-type-builder.ts
+++ b/src/provable-type-builder.ts
@@ -58,11 +58,18 @@ class TypeBuilder<T, V> {
     });
   }
 
-  mapValue<W>(transform: {
-    there: (x: V) => W;
-    back: (x: W) => V;
-    distinguish: (x: T | W) => x is T;
-  }): TypeBuilder<T, W> {
+  mapValue<W>(
+    transform:
+      | {
+          there: (x: V) => W;
+          back: (x: W) => V;
+          distinguish: (x: T | W) => x is T;
+        }
+      | {
+          there: (x: V) => W;
+          backAndDistinguish: (x: W | T) => V | T;
+        }
+  ): TypeBuilder<T, W> {
     let type = this.type;
     return new TypeBuilder({
       ...type,
@@ -71,6 +78,9 @@ class TypeBuilder<T, V> {
         return transform.there(type.toValue(value));
       },
       fromValue(value) {
+        if ('backAndDistinguish' in transform) {
+          return type.fromValue(transform.backAndDistinguish(value));
+        }
         if (transform.distinguish(value)) return value;
         return type.fromValue(transform.back(value));
       },
@@ -109,11 +119,18 @@ class TypeBuilderPure<T, V> extends TypeBuilder<T, V> {
     return super.forConstructor(constructor) as TypeBuilderPure<C, V>;
   }
 
-  mapValue<W>(transform: {
-    there: (x: V) => W;
-    back: (x: W) => V;
-    distinguish: (x: T | W) => x is T;
-  }): TypeBuilderPure<T, W> {
+  mapValue<W>(
+    transform:
+      | {
+          there: (x: V) => W;
+          back: (x: W) => V;
+          distinguish: (x: T | W) => x is T;
+        }
+      | {
+          there: (x: V) => W;
+          backAndDistinguish: (x: W | T) => V | T;
+        }
+  ): TypeBuilderPure<T, W> {
     return super.mapValue(transform) as TypeBuilderPure<T, W>;
   }
 

--- a/src/provable-type-builder.ts
+++ b/src/provable-type-builder.ts
@@ -10,7 +10,7 @@ import {
   type Field,
 } from 'o1js';
 import type { NestedProvable } from './nested.ts';
-import type { ProvableHashablePure } from './o1js-missing.ts';
+import type { HashInput, ProvableHashablePure } from './o1js-missing.ts';
 
 export { TypeBuilder, TypeBuilderPure };
 
@@ -86,6 +86,11 @@ class TypeBuilder<T, V> {
       originalCheck(x);
       check(x);
     });
+  }
+
+  hashInput(toInput: (x: T) => HashInput): TypeBuilder<T, V> {
+    let type = this.type;
+    return new TypeBuilder({ ...type, toInput });
   }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,6 +8,7 @@ export {
   zip,
   chunk,
   pad,
+  fill,
   mapObject,
   mapEntries,
   zipObjects,
@@ -93,6 +94,12 @@ function pad<T>(array: T[], size: number, value: T | (() => T)): T[] {
   let cb: () => T =
     typeof value === 'function' ? (value as () => T) : () => value;
   return array.concat(Array.from({ length: size - array.length }, cb));
+}
+
+function fill<T>(size: number, value: T | (() => T)): T[] {
+  let cb: () => T =
+    typeof value === 'function' ? (value as () => T) : () => value;
+  return Array.from({ length: size }, cb);
 }
 
 function mapObject<

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,6 +2,7 @@ export {
   assert,
   assertDefined,
   defined,
+  Required,
   assertHasProperty,
   hasProperty,
   assertIsObject,
@@ -40,6 +41,21 @@ function assertDefined<T>(
 function defined<T>(input: T | undefined, message?: string): T {
   assertDefined(input, message);
   return input;
+}
+
+function Required<T extends {}>(
+  t: T
+): {
+  [P in keyof T]-?: T[P];
+} {
+  return new Proxy(t, {
+    get(target, key) {
+      return defined(
+        (target as any)[key],
+        `Property "${String(key)}" is undefined`
+      );
+    },
+  }) as Required<T>;
 }
 
 function assertIsObject(

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
 export {
   assert,
   assertDefined,
+  defined,
   assertHasProperty,
   hasProperty,
   assertIsObject,
@@ -14,6 +15,7 @@ export {
   zipObjects,
   assertExtendsShape,
   isSubclass,
+  stringLength,
 };
 
 function assert(
@@ -33,6 +35,11 @@ function assertDefined<T>(
   if (input === undefined) {
     throw Error(message ?? 'Input is undefined');
   }
+}
+
+function defined<T>(input: T | undefined, message?: string): T {
+  assertDefined(input, message);
+  return input;
 }
 
 function assertIsObject(
@@ -150,4 +157,10 @@ function isSubclass<B extends Constructor<any>>(
   if (typeof constructor !== 'function') return false;
   if (!hasProperty(constructor, 'prototype')) return false;
   return constructor.prototype instanceof base;
+}
+
+let enc = new TextEncoder();
+
+function stringLength(str: string): number {
+  return enc.encode(str).length;
 }


### PR DESCRIPTION
continuing from https://github.com/zksecurity/mina-credentials/pull/62, this expands the scope of dynamic-schema-friendly hashing,

* make nested records work correctly (inner records are hashed dynamically as well)
* hash dynamic arrays - in particular, strings - such that the hash only depends on the actual elements (not the padding)
* hash primitive JS types (number, boolean, undefined, ...)
* general-purpose `hashDynamic()` and `packToField()` methods that work basically on anything, in a way that is compatible with `DynamicArray.hash()` (for arrays / strings) and `DynamicRecord.hash()` (for objects)

mostly finishes #68 

TODOs:
* [x] tests for complicated dynamic arrays
* [x] tests for subschemas of nested records
* [x] hash plain arrays such that it's compatible with dynamic arrays
* [x] `assertEquals()`, `assertStrictlyEquals()` for `DynamicArray`
* [ ] easy and well-defined schema definition API
  * including generic strings, bytes and other arrays without specifying max size
  * left for next PR