### PR TITLE
Schema definition

### DIFF
--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -7,7 +7,6 @@ import {
   Presentation,
   PresentationRequest,
   assert,
-  type InferSchema,
   DynamicString,
   DynamicArray,
   hashPacked,
@@ -20,27 +19,27 @@ import {
   randomPublicKey,
 } from '../tests/test-utils.ts';
 import { DynamicRecord } from '../src/credentials/dynamic-record.ts';
+import { Schema } from '../src/credentials/schema.ts';
 
 // example schema of the credential, which has enough entropy to be hashed into a unique id
 const String = DynamicString({ maxLength: 50 });
-const LongString = DynamicString({ maxLength: 200 });
 const Bytes16 = Bytes(16);
 
-const Schema = {
+const schema = Schema({
   /**
    * Nationality of the owner.
    */
-  nationality: String,
+  nationality: Schema.String,
 
   /**
    * Full name of the owner.
    */
-  name: LongString,
+  name: Schema.String,
 
   /**
    * Date of birth of the owner.
    */
-  birthDate: UInt64,
+  birthDate: Schema.Number,
 
   /**
    * Owner ID (16 bytes).
@@ -50,19 +49,19 @@ const Schema = {
   /**
    * Timestamp when the credential expires.
    */
-  expiresAt: UInt64,
-};
+  expiresAt: Schema.Number,
+});
 
 // ---------------------------------------------
 // ISSUER: issue a signed credential to the owner
 
-let data: InferSchema<typeof Schema> = {
-  nationality: String.from('United States of America'),
-  name: LongString.from('John Doe'),
-  birthDate: UInt64.from(Date.UTC(1990, 1, 1)),
+let data = schema.from({
+  nationality: 'United States of America',
+  name: 'John Doe',
+  birthDate: Date.UTC(1990, 1, 1),
   id: Bytes16.random(),
-  expiresAt: UInt64.from(Date.UTC(2028, 7, 1)),
-};
+  expiresAt: Date.UTC(2028, 7, 1),
+});
 let credential = Credential.sign(issuerKey, { owner, data });
 let credentialJson = Credential.toJSON(credential);
 

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -38,7 +38,7 @@ const schema = Schema({
   /**
    * Date of birth of the owner.
    */
-  birthDate: UInt64,
+  birthDate: Schema.Number,
 
   /**
    * Owner ID (16 bytes).
@@ -48,7 +48,7 @@ const schema = Schema({
   /**
    * Timestamp when the credential expires.
    */
-  expiresAt: UInt64,
+  expiresAt: Schema.Number,
 });
 
 // ---------------------------------------------
@@ -57,9 +57,9 @@ const schema = Schema({
 let data = schema.from({
   nationality: 'United States of America',
   name: 'John Doe',
-  birthDate: UInt64.from(Date.UTC(1990, 1, 1)),
+  birthDate: Date.UTC(1990, 1, 1),
   id: Bytes16.random(),
-  expiresAt: UInt64.from(Date.UTC(2028, 7, 1)),
+  expiresAt: Date.UTC(2028, 7, 1),
 });
 let credential = Credential.sign(issuerKey, { owner, data });
 let credentialJson = Credential.toJSON(credential);

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -22,7 +22,6 @@ import { DynamicRecord } from '../src/credentials/dynamic-record.ts';
 import { Schema } from '../src/credentials/schema.ts';
 
 // example schema of the credential, which has enough entropy to be hashed into a unique id
-const String = DynamicString({ maxLength: 50 });
 const Bytes16 = Bytes(16);
 
 const schema = Schema({
@@ -93,6 +92,7 @@ const Subschema = DynamicRecord(
   { maxEntries: 20 }
 );
 
+const String = DynamicString({ maxLength: 50 });
 const FieldArray = DynamicArray(Field, { maxLength: 100 });
 
 const spec = Spec(
@@ -114,6 +114,7 @@ const spec = Spec(
     // 2. the credential was issued by one of the accepted issuers
     // 3. the credential is not expired (by comparing with the current date)
     let assert = Operation.and(
+      // TODO hash() must use hashDynamic()
       Operation.equalsOneOf(Operation.hash(nationality), acceptedNations),
       Operation.equalsOneOf(issuer, acceptedIssuers),
       Operation.lessThanEq(currentDate, expiresAt)
@@ -139,6 +140,7 @@ let request = PresentationRequest.https(
   spec,
   {
     acceptedNations: FieldArray.from(
+      // TODO we want hashDynamic here
       acceptedNations.map((s) => hashPacked(String, String.from(s)))
     ),
     acceptedIssuers: FieldArray.from(acceptedIssuers),

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -10,6 +10,8 @@ import {
   DynamicString,
   DynamicArray,
   hashPacked,
+  DynamicRecord,
+  Schema,
 } from '../src/index.ts';
 import {
   issuer,
@@ -18,8 +20,6 @@ import {
   ownerKey,
   randomPublicKey,
 } from '../tests/test-utils.ts';
-import { DynamicRecord } from '../src/credentials/dynamic-record.ts';
-import { Schema } from '../src/credentials/schema.ts';
 
 // example schema of the credential, which has enough entropy to be hashed into a unique id
 const Bytes16 = Bytes(16);

--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -38,7 +38,7 @@ const schema = Schema({
   /**
    * Date of birth of the owner.
    */
-  birthDate: Schema.Number,
+  birthDate: UInt64,
 
   /**
    * Owner ID (16 bytes).
@@ -48,7 +48,7 @@ const schema = Schema({
   /**
    * Timestamp when the credential expires.
    */
-  expiresAt: Schema.Number,
+  expiresAt: UInt64,
 });
 
 // ---------------------------------------------
@@ -57,9 +57,9 @@ const schema = Schema({
 let data = schema.from({
   nationality: 'United States of America',
   name: 'John Doe',
-  birthDate: Date.UTC(1990, 1, 1),
+  birthDate: UInt64.from(Date.UTC(1990, 1, 1)),
   id: Bytes16.random(),
-  expiresAt: Date.UTC(2028, 7, 1),
+  expiresAt: UInt64.from(Date.UTC(2028, 7, 1)),
 });
 let credential = Credential.sign(issuerKey, { owner, data });
 let credentialJson = Credential.toJSON(credential);

--- a/src/credential-index.ts
+++ b/src/credential-index.ts
@@ -92,17 +92,9 @@ async function validateCredential(
 
   assert(knownWitness(credential.witness), 'Unknown credential type');
 
-  // TODO: this is brittle. probably data type should be part of metadata.
-  let data = NestedProvable.get(
-    NestedProvable.fromValue(credential.credential.data)
+  let spec = getCredentialSpec(credential.witness)(
+    Schema.nestedType(credential.credential.data)
   );
-  let spec = getCredentialSpec(credential.witness)(data);
-
-  // TODO: do this?
-  // let spec = getCredentialSpec(credential.witness)(
-  //   // nestedType() would feel more natural here but is rejected as type
-  //   Schema.type(credential.credential.data)
-  // );
 
   let credHash = hashCredential(credential.credential);
   await spec.verifyOutsideCircuit(credential.witness, credHash);

--- a/src/credential-signed.ts
+++ b/src/credential-signed.ts
@@ -61,8 +61,7 @@ function createSigned<Data>(
   credential: Credential<Data>
 ): Signed<Data> {
   let issuer = issuerPrivateKey.toPublicKey();
-  let dataType = NestedProvable.fromValue(credential.data);
-  let credHash = hashCredential(dataType, credential);
+  let credHash = hashCredential(credential);
   let issuerSignature = Signature.create(issuerPrivateKey, [credHash.hash]);
 
   return {

--- a/src/credentials/dynamic-array.ts
+++ b/src/credentials/dynamic-array.ts
@@ -17,6 +17,7 @@ import { assert, assertHasProperty, chunk, fill, pad, zip } from '../util.ts';
 import {
   type ProvableHashablePure,
   type ProvableHashableType,
+  type ProvableHashableWide,
   ProvableType,
 } from '../o1js-missing.ts';
 import {
@@ -39,12 +40,16 @@ import { BaseType } from './dynamic-base-types.ts';
 
 export { DynamicArray };
 
-export { DynamicArrayBase, provable as provableDynamicArray };
+export {
+  DynamicArrayBase,
+  provable as provableDynamicArray,
+  type DynamicArrayClass,
+};
 
 type DynamicArray<T = any, V = any> = DynamicArrayBase<T, V>;
 
 type DynamicArrayClass<T, V> = typeof DynamicArrayBase<T, V> & {
-  provable: ProvableHashable<DynamicArrayBase<T, V>, V[]>;
+  provable: ProvableHashableWide<DynamicArrayBase<T, V>, V[], (T | V)[]>;
 
   /**
    * Create a new DynamicArray from an array of values.
@@ -56,7 +61,7 @@ type DynamicArrayClass<T, V> = typeof DynamicArrayBase<T, V> & {
 
 type DynamicArrayClassPure<T, V> = typeof DynamicArrayBase<T, V> &
   Omit<DynamicArrayClass<T, V>, 'provable'> & {
-    provable: ProvableHashable<DynamicArrayBase<T, V>, V[]> &
+    provable: ProvableHashableWide<DynamicArrayBase<T, V>, V[], (T | V)[]> &
       ProvablePure<DynamicArrayBase<T, V>, V[]>;
   };
 

--- a/src/credentials/dynamic-hash.ts
+++ b/src/credentials/dynamic-hash.ts
@@ -35,6 +35,8 @@ export {
   hashRecord,
   bitSize,
   packedFieldSize,
+  provableTypeOf,
+  innerArrayType,
 };
 
 // compatible hashing

--- a/src/credentials/dynamic-record.test.ts
+++ b/src/credentials/dynamic-record.test.ts
@@ -36,7 +36,7 @@ let original = OriginalSchema.from({
 });
 const expectedHash = hashRecord(original);
 
-const OriginalWrappedInStruct = Struct(Schema.nestedType(original));
+const OriginalWrappedInStruct = Struct(OriginalSchema.nestedType(original));
 let originalStruct = OriginalWrappedInStruct.fromValue(original);
 
 console.dir({ original, originalStruct }, { depth: 6 });
@@ -126,7 +126,7 @@ async function circuit() {
   });
 
   await test('hashCredential()', () => {
-    let type = Schema.type(original);
+    let type = OriginalSchema.type(original);
     let originalHash = hashCredential(type, {
       owner,
       data: type.fromValue(original),

--- a/src/credentials/dynamic-record.test.ts
+++ b/src/credentials/dynamic-record.test.ts
@@ -46,8 +46,10 @@ let original = OriginalSchema.from({
 });
 const expectedHash = hashRecord(original);
 
-const OriginalWrappedInStruct = Struct(OriginalSchema.type(original));
+const OriginalWrappedInStruct = Struct(Schema.nestedType(original));
 let originalStruct = OriginalWrappedInStruct.fromValue(original);
+
+console.dir({ original, originalStruct }, { depth: 6 });
 
 // subset schema and circuit that doesn't know the full original layout
 
@@ -133,9 +135,10 @@ async function circuit() {
   });
 
   await test('hashCredential()', () => {
-    let originalHash = hashCredential(OriginalSchema.type(original), {
+    let type = Schema.type(original);
+    let originalHash = hashCredential(type, {
       owner,
-      data: original,
+      data: type.fromValue(original),
     }).hash;
 
     let originalStructHash = hashCredential(OriginalWrappedInStruct, {

--- a/src/credentials/dynamic-record.test.ts
+++ b/src/credentials/dynamic-record.test.ts
@@ -83,12 +83,13 @@ async function circuit() {
   await test('DynamicRecord.getAny()', () => {
     // we can get the other fields as well, if we know their type
     record.getAny(Bool, 'second').assertEquals(true, 'second');
-    record.getAny(UInt64, 'fourth').assertEquals(UInt64.from(123n));
+    record.getAny(UInt32, 'fourth').assertEquals(UInt32.from(123n));
 
     // `packToField()` collisions mean that we can also reinterpret fields into types with equivalent packing
     // (if the new type's `fromValue()` allows the original value)
     record.getAny(Bool, 'first').assertEquals(true, 'first');
     record.getAny(UInt64, 'first').assertEquals(UInt64.one);
+    record.getAny(UInt64, 'fourth').assertEquals(UInt64.from(123n));
 
     // we can get a nested record as struct (and nested strings can have different length)
     // this works because structs are hashed in dynamic record style

--- a/src/credentials/dynamic-record.test.ts
+++ b/src/credentials/dynamic-record.test.ts
@@ -1,4 +1,4 @@
-import { Bool, Field, Provable, Struct, UInt64 } from 'o1js';
+import { Bool, Field, Provable, Struct, UInt32, UInt64 } from 'o1js';
 import { DynamicRecord } from './dynamic-record.ts';
 import { DynamicString } from './dynamic-string.ts';
 import { test } from 'node:test';
@@ -18,12 +18,12 @@ const OriginalSchema = Schema({
   first: Field,
   second: Schema.Boolean,
   third: Schema.String,
-  fourth: Schema.Bigint,
+  fourth: UInt32,
   fifth: {
     field: Schema.Number,
     string: Schema.String,
   },
-  sixth: Schema.Array(Schema.Bigint),
+  sixth: Schema.Array(Schema.Number),
 });
 
 let original = OriginalSchema.from({
@@ -32,7 +32,7 @@ let original = OriginalSchema.from({
   third: 'something',
   fourth: 123n,
   fifth: { field: 2, string: '...' },
-  sixth: [1n, 2n, 3n],
+  sixth: [1, 2, 3],
 });
 const expectedHash = hashRecord(original);
 
@@ -101,7 +101,7 @@ async function circuit() {
     );
 
     // can get an array as dynamic array, as long as the maxLength is >= the actual length
-    const SixthDynamic = DynamicArray(Field, { maxLength: 7 });
+    const SixthDynamic = DynamicArray(UInt64, { maxLength: 7 });
     let sixth = record.getAny(SixthDynamic, 'sixth');
     sixth.assertEqualsStrict(SixthDynamic.from(original.sixth));
 

--- a/src/credentials/dynamic-record.test.ts
+++ b/src/credentials/dynamic-record.test.ts
@@ -39,8 +39,6 @@ const expectedHash = hashRecord(original);
 const OriginalWrappedInStruct = Struct(OriginalSchema.nestedType(original));
 let originalStruct = OriginalWrappedInStruct.fromValue(original);
 
-console.dir({ original, originalStruct }, { depth: 6 });
-
 // subset schema and circuit that doesn't know the full original layout
 
 const Subschema = DynamicRecord(
@@ -126,20 +124,19 @@ async function circuit() {
   });
 
   await test('hashCredential()', () => {
-    let type = OriginalSchema.type(original);
-    let originalHash = hashCredential(type, {
+    let originalHash = hashCredential({
       owner,
-      data: type.fromValue(original),
+      data: original,
     }).hash;
 
-    let originalStructHash = hashCredential(OriginalWrappedInStruct, {
+    let originalStructHash = hashCredential({
       owner,
       data: originalStruct,
     }).hash;
 
     originalStructHash.assertEquals(originalHash, 'hashCredential() (struct)');
 
-    let subschemaHash = hashCredential(Subschema, { owner, data: record }).hash;
+    let subschemaHash = hashCredential({ owner, data: record }).hash;
     subschemaHash.assertEquals(
       originalHash,
       'hashCredential() (dynamic record)'

--- a/src/credentials/dynamic-record.ts
+++ b/src/credentials/dynamic-record.ts
@@ -45,8 +45,9 @@ export {
 
 type DynamicRecord<TKnown = any> = DynamicRecordBase<TKnown>;
 
-type DynamicRecordClass<AKnown extends Record<string, ProvableHashableType>> =
-  ReturnType<typeof DynamicRecord<AKnown>>;
+type DynamicRecordClass<AKnown extends Record<string, any>> = ReturnType<
+  typeof DynamicRecord<AKnown>
+>;
 
 function DynamicRecord<
   AKnown extends Record<string, ProvableHashableType>,

--- a/src/credentials/dynamic-record.ts
+++ b/src/credentials/dynamic-record.ts
@@ -35,9 +35,18 @@ import {
 import { hashString, packToField } from './dynamic-hash.ts';
 import { BaseType } from './dynamic-base-types.ts';
 
-export { DynamicRecord, GenericRecord, type UnknownRecord, extractProperty };
+export {
+  DynamicRecord,
+  GenericRecord,
+  type UnknownRecord,
+  type DynamicRecordClass,
+  extractProperty,
+};
 
 type DynamicRecord<TKnown = any> = DynamicRecordBase<TKnown>;
+
+type DynamicRecordClass<AKnown extends Record<string, ProvableHashableType>> =
+  ReturnType<typeof DynamicRecord<AKnown>>;
 
 function DynamicRecord<
   AKnown extends Record<string, ProvableHashableType>,

--- a/src/credentials/schema.ts
+++ b/src/credentials/schema.ts
@@ -68,9 +68,11 @@ function Schema<T extends Record<string, SchemaType>>(schema: T) {
 
 // loosely-typed versions of the above functions that work without a schema object
 
-Schema.nestedType = function nestedType<S>(value: S): {
-  [key in keyof S]: ProvableHashableType<S[key], S[key]>;
-} {
+Schema.nestedType = function nestedType<S>(value: S): unknown extends S
+  ? NestedProvable
+  : {
+      [key in keyof S]: ProvableHashableType<S[key], S[key]>;
+    } {
   return mapObject<any, any>(value, (v: unknown) => provableTypeOf(v));
 };
 Schema.type = function type<S>(value: S): ProvableHashable<S, S> {

--- a/src/credentials/schema.ts
+++ b/src/credentials/schema.ts
@@ -1,16 +1,12 @@
 import {
-  Bool,
-  Field,
   type From,
   type InferProvable,
   type ProvableHashable,
   UInt64,
 } from 'o1js';
-import { assert, mapObject, stringLength, zipObjects } from '../util.ts';
+import { assert, mapObject, zipObjects } from '../util.ts';
 import { type ProvableHashableType, ProvableType } from '../o1js-missing.ts';
-import { DynamicString } from './dynamic-string.ts';
-import { DynamicArray } from './dynamic-array.ts';
-import { innerArrayType, provableTypeOf } from './dynamic-hash.ts';
+import { provableTypeOf } from './dynamic-hash.ts';
 import { NestedProvable } from '../nested.ts';
 
 export { Schema };
@@ -20,14 +16,12 @@ type SchemaType =
   | SchemaString
   | SchemaNumber
   | SchemaBoolean
-  | SchemaBigint
   | { type: 'array'; inner: SchemaType }
   | { [key in string]: SchemaType };
 
 type SchemaString = { type: 'string' };
 type SchemaNumber = { type: 'number' };
 type SchemaBoolean = { type: 'boolean' };
-type SchemaBigint = { type: 'bigint' };
 type SchemaArray<T extends SchemaType = SchemaType> = {
   type: 'array';
   inner: T;
@@ -58,7 +52,6 @@ Schema.type = function type<S extends SchemaOutput<unknown>>(
 Schema.String = { type: 'string' } satisfies SchemaType;
 Schema.Number = { type: 'number' } satisfies SchemaType;
 Schema.Boolean = { type: 'boolean' } satisfies SchemaType;
-Schema.Bigint = { type: 'bigint' } satisfies SchemaType;
 Schema.Array = function SchemaArray<T extends SchemaType>(
   inner: T
 ): SchemaArray<T> {
@@ -80,9 +73,6 @@ function validateAndConvert(schema: SchemaType, value: unknown): any {
     case 'boolean':
       assert(typeof value === 'boolean');
       return value;
-    case 'bigint':
-      assert(typeof value === 'bigint');
-      return value;
     case 'array':
       assert(Array.isArray(value));
       return value.map((v) => validateAndConvert(schema.inner, v));
@@ -103,8 +93,6 @@ type SchemaInput<T extends SchemaType = SchemaType> =
     ? number
     : T extends SchemaBoolean
     ? boolean
-    : T extends SchemaBigint
-    ? bigint
     : T extends SchemaArray<infer U>
     ? SchemaInput<U>[]
     : T extends { [key in string]: SchemaType }
@@ -120,8 +108,6 @@ type SchemaOutput<T = SchemaType> = T extends ProvableHashableType
   ? UInt64
   : T extends SchemaBoolean
   ? boolean
-  : T extends SchemaBigint
-  ? bigint
   : T extends SchemaArray<infer U>
   ? SchemaOutput<U>[]
   : { [key in keyof T]: SchemaOutput<T[key]> };

--- a/src/credentials/schema.ts
+++ b/src/credentials/schema.ts
@@ -33,7 +33,9 @@ function Schema<T extends Record<string, SchemaType>>(
 
   from(value: SchemaInput<T>): SchemaOutput<T>;
 
-  type(value: SchemaOutput<T>): NestedProvableFor<SchemaOutput<T>>;
+  type(value: SchemaOutput<T>): {
+    [key in keyof T]: ProvableHashableType<SchemaOutput<T>[key]>;
+  };
 } {
   return {
     schema,

--- a/src/credentials/schema.ts
+++ b/src/credentials/schema.ts
@@ -1,13 +1,21 @@
 import {
+  Bool,
   type From,
   type InferProvable,
-  type ProvableHashable,
+  type InferValue,
   UInt64,
 } from 'o1js';
 import { assert, mapObject, zipObjects } from '../util.ts';
-import { type ProvableHashableType, ProvableType } from '../o1js-missing.ts';
+import {
+  type ProvableHashableType,
+  type ProvableHashableWide,
+  ProvableType,
+} from '../o1js-missing.ts';
 import { provableTypeOf } from './dynamic-hash.ts';
 import { NestedProvable } from '../nested.ts';
+import type { DynamicString } from './dynamic-string.ts';
+import type { DynamicArrayClass } from './dynamic-array.ts';
+import type { DynamicRecordClass } from './dynamic-record.ts';
 
 export { Schema };
 
@@ -34,20 +42,43 @@ function Schema<T extends Record<string, SchemaType>>(schema: T) {
     from(value: SchemaInput<T>): SchemaOutput<T> {
       return validateAndConvert(schema, value);
     },
+
+    nestedType(value: SchemaOutput<T>): {
+      [key in keyof T]: ProvableTypeOf<T[key]>;
+    } {
+      return mapObject<any, any>(value, (v: unknown) => provableTypeOf(v));
+    },
+
+    type(value: SchemaOutput<T>): ProvableHashableWide<
+      {
+        [key in keyof T]: InferProvable<ProvableTypeOf<T[key]>>;
+      },
+      {
+        [key in keyof T]: InferValue<ProvableTypeOf<T[key]>>;
+      },
+      {
+        [key in keyof T]: From<ProvableTypeOf<T[key]>>;
+      }
+    > {
+      return NestedProvable.get(this.nestedType(value) as any) as any;
+    },
   };
 }
-Schema.nestedType = function nestedType<S extends SchemaOutput<unknown>>(
-  value: S
-): {
-  [key in keyof S]: ProvableHashableType<S[key], S[key]>;
-} {
-  return mapObject<any, any>(value, (v: unknown) => provableTypeOf(v));
-};
-Schema.type = function type<S extends SchemaOutput<unknown>>(
-  value: S
-): ProvableHashable<S, S> {
-  return NestedProvable.get(Schema.nestedType(value));
-};
+
+// TODO probably won't need this -- looser-typed versions of the above functions
+
+// Schema.nestedType = function nestedType<S extends SchemaOutput<unknown>>(
+//   value: S
+// ): {
+//   [key in keyof S]: ProvableHashableType<S[key], S[key]>;
+// } {
+//   return mapObject<any, any>(value, (v: unknown) => provableTypeOf(v));
+// };
+// Schema.type = function type<S extends SchemaOutput<unknown>>(
+//   value: S
+// ): ProvableHashable<S, S> {
+//   return NestedProvable.get(Schema.nestedType(value));
+// };
 
 Schema.String = { type: 'string' } satisfies SchemaType;
 Schema.Number = { type: 'number' } satisfies SchemaType;
@@ -84,20 +115,19 @@ function validateAndConvert(schema: SchemaType, value: unknown): any {
   }
 }
 
-type SchemaInput<T extends SchemaType = SchemaType> =
-  T extends ProvableHashableType
-    ? From<T>
-    : T extends SchemaString
-    ? string
-    : T extends SchemaNumber
-    ? number
-    : T extends SchemaBoolean
-    ? boolean
-    : T extends SchemaArray<infer U>
-    ? SchemaInput<U>[]
-    : T extends { [key in string]: SchemaType }
-    ? { [key in keyof T]: SchemaInput<T[key]> }
-    : never;
+type SchemaInput<T = SchemaType> = T extends ProvableHashableType
+  ? From<T>
+  : T extends SchemaString
+  ? string
+  : T extends SchemaNumber
+  ? number
+  : T extends SchemaBoolean
+  ? boolean
+  : T extends SchemaArray<infer U>
+  ? SchemaInput<U>[]
+  : T extends { [key in string]: SchemaType }
+  ? { [key in keyof T]: SchemaInput<T[key]> }
+  : never;
 
 // TODO: this type is hard for TS to process
 type SchemaOutput<T = SchemaType> = T extends ProvableHashableType
@@ -111,3 +141,23 @@ type SchemaOutput<T = SchemaType> = T extends ProvableHashableType
   : T extends SchemaArray<infer U>
   ? SchemaOutput<U>[]
   : { [key in keyof T]: SchemaOutput<T[key]> };
+
+/**
+ * Type version of `provableTypeOf()`.
+ */
+type ProvableTypeOf<T> = T extends ProvableHashableType
+  ? T
+  : T extends SchemaString
+  ? ReturnType<typeof DynamicString>
+  : T extends SchemaNumber
+  ? typeof UInt64
+  : T extends SchemaBoolean
+  ? typeof Bool
+  : T extends SchemaArray<infer U>
+  ? DynamicArrayClass<
+      InferProvable<ProvableTypeOf<U>>,
+      InferValue<ProvableTypeOf<U>>
+    >
+  : T extends { [key in string]: SchemaType }
+  ? DynamicRecordClass<{ [key in keyof T]: ProvableTypeOf<T[key]> }>
+  : never;

--- a/src/credentials/schema.ts
+++ b/src/credentials/schema.ts
@@ -1,0 +1,123 @@
+import { Bool, Field, type From, type InferProvable, UInt64 } from 'o1js';
+import { assert, mapObject, stringLength, zipObjects } from '../util.ts';
+import { type ProvableHashableType, ProvableType } from '../o1js-missing.ts';
+import { DynamicString } from './dynamic-string.ts';
+import { DynamicArray } from './dynamic-array.ts';
+import { innerArrayType, provableTypeOf } from './dynamic-hash.ts';
+import type { NestedProvableFor } from '../nested.ts';
+
+export { Schema };
+
+type SchemaType =
+  | ProvableHashableType
+  | SchemaString
+  | SchemaNumber
+  | SchemaBoolean
+  | SchemaBigint
+  | { type: 'array'; inner: SchemaType }
+  | { [key in string]: SchemaType };
+
+type SchemaString = { type: 'string' };
+type SchemaNumber = { type: 'number' };
+type SchemaBoolean = { type: 'boolean' };
+type SchemaBigint = { type: 'bigint' };
+type SchemaArray<T extends SchemaType = SchemaType> = {
+  type: 'array';
+  inner: T;
+};
+
+function Schema<T extends Record<string, SchemaType>>(
+  schema: T
+): {
+  schema: T;
+
+  from(value: SchemaInput<T>): SchemaOutput<T>;
+
+  type(value: SchemaOutput<T>): NestedProvableFor<SchemaOutput<T>>;
+} {
+  return {
+    schema,
+
+    from(value) {
+      return (validateAndConvert as any)(schema, value);
+    },
+
+    type(value) {
+      return mapObject<any, any>(value, (v: unknown) => provableTypeOf(v));
+    },
+  };
+}
+
+Schema.String = { type: 'string' } satisfies SchemaType;
+Schema.Number = { type: 'number' } satisfies SchemaType;
+Schema.Boolean = { type: 'boolean' } satisfies SchemaType;
+Schema.Bigint = { type: 'bigint' } satisfies SchemaType;
+Schema.Array = function SchemaArray<T extends SchemaType>(
+  inner: T
+): SchemaArray<T> {
+  return { type: 'array', inner };
+};
+
+function validateAndConvert(schema: SchemaType, value: unknown): any {
+  if (ProvableType.isProvableHashableType(schema)) {
+    return ProvableType.get(schema).fromValue(value);
+  }
+  switch (schema.type) {
+    case 'string':
+      assert(typeof value === 'string');
+      return DynamicString({ maxLength: stringLength(value) }).from(value);
+    case 'number':
+      assert(typeof value === 'number');
+      assert(Number.isInteger(value));
+      return UInt64.from(value);
+    case 'boolean':
+      assert(typeof value === 'boolean');
+      return Bool(value);
+    case 'bigint':
+      assert(typeof value === 'bigint');
+      return Field(value);
+    case 'array':
+      assert(Array.isArray(value));
+      let innerType = innerArrayType(value);
+      return DynamicArray(innerType, { maxLength: value.length }).from(
+        value.map((v: unknown) => validateAndConvert(schema.inner, v))
+      );
+    default:
+      assert(typeof value === 'object' && value !== null);
+      return mapObject(zipObjects(schema, value), ([s, v]) =>
+        validateAndConvert(s, v)
+      );
+  }
+}
+
+type SchemaInput<T extends SchemaType = SchemaType> =
+  T extends ProvableHashableType
+    ? From<T>
+    : T extends SchemaString
+    ? string
+    : T extends SchemaNumber
+    ? number
+    : T extends SchemaBoolean
+    ? boolean
+    : T extends SchemaBigint
+    ? bigint
+    : T extends SchemaArray<infer U>
+    ? SchemaInput<U>[]
+    : T extends { [key in string]: SchemaType }
+    ? { [key in keyof T]: SchemaInput<T[key]> }
+    : never;
+
+// TODO: this type is somehow breaking TS completely
+type SchemaOutput<T = SchemaType> = T extends ProvableHashableType
+  ? InferProvable<T>
+  : T extends SchemaString
+  ? DynamicString
+  : T extends SchemaNumber
+  ? UInt64
+  : T extends SchemaBoolean
+  ? Bool
+  : T extends SchemaBigint
+  ? Field
+  : T extends SchemaArray<infer U>
+  ? DynamicArray<SchemaOutput<U>>
+  : { [key in keyof T]: SchemaOutput<T[key]> };

--- a/src/credentials/schema.ts
+++ b/src/credentials/schema.ts
@@ -36,6 +36,15 @@ type SchemaArray<T extends SchemaType = SchemaType> = {
   inner: T;
 };
 
+Schema.String = { type: 'string' } satisfies SchemaType;
+Schema.Number = { type: 'number' } satisfies SchemaType;
+Schema.Boolean = { type: 'boolean' } satisfies SchemaType;
+Schema.Array = function SchemaArray<T extends SchemaType>(
+  inner: T
+): SchemaArray<T> {
+  return { type: 'array', inner };
+};
+
 function Schema<T extends Record<string, SchemaType>>(schema: T) {
   return {
     schema,
@@ -77,15 +86,6 @@ Schema.nestedType = function nestedType<S>(value: S): unknown extends S
 };
 Schema.type = function type<S>(value: S): ProvableHashable<S, S> {
   return NestedProvable.get(Schema.nestedType(value));
-};
-
-Schema.String = { type: 'string' } satisfies SchemaType;
-Schema.Number = { type: 'number' } satisfies SchemaType;
-Schema.Boolean = { type: 'boolean' } satisfies SchemaType;
-Schema.Array = function SchemaArray<T extends SchemaType>(
-  inner: T
-): SchemaArray<T> {
-  return { type: 'array', inner };
 };
 
 function validateAndConvert(schema: SchemaType, value: unknown): any {

--- a/src/credentials/schema.ts
+++ b/src/credentials/schema.ts
@@ -1,5 +1,5 @@
 import {
-  Bool,
+  type Bool,
   type From,
   type InferProvable,
   type InferValue,

--- a/src/credentials/schema.ts
+++ b/src/credentials/schema.ts
@@ -3,6 +3,7 @@ import {
   type From,
   type InferProvable,
   type InferValue,
+  type ProvableHashable,
   UInt64,
 } from 'o1js';
 import { assert, mapObject, zipObjects } from '../util.ts';
@@ -65,20 +66,16 @@ function Schema<T extends Record<string, SchemaType>>(schema: T) {
   };
 }
 
-// TODO probably won't need this -- looser-typed versions of the above functions
+// loosely-typed versions of the above functions that work without a schema object
 
-// Schema.nestedType = function nestedType<S extends SchemaOutput<unknown>>(
-//   value: S
-// ): {
-//   [key in keyof S]: ProvableHashableType<S[key], S[key]>;
-// } {
-//   return mapObject<any, any>(value, (v: unknown) => provableTypeOf(v));
-// };
-// Schema.type = function type<S extends SchemaOutput<unknown>>(
-//   value: S
-// ): ProvableHashable<S, S> {
-//   return NestedProvable.get(Schema.nestedType(value));
-// };
+Schema.nestedType = function nestedType<S>(value: S): {
+  [key in keyof S]: ProvableHashableType<S[key], S[key]>;
+} {
+  return mapObject<any, any>(value, (v: unknown) => provableTypeOf(v));
+};
+Schema.type = function type<S>(value: S): ProvableHashable<S, S> {
+  return NestedProvable.get(Schema.nestedType(value));
+};
 
 Schema.String = { type: 'string' } satisfies SchemaType;
 Schema.Number = { type: 'number' } satisfies SchemaType;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,6 @@ export { DynamicArray } from './credentials/dynamic-array.ts';
 export { StaticArray } from './credentials/static-array.ts';
 export { DynamicBytes } from './credentials/dynamic-bytes.ts';
 export { DynamicString } from './credentials/dynamic-string.ts';
+export { DynamicRecord } from './credentials/dynamic-record.ts';
 export { hashPacked } from './o1js-missing.ts';
-
-export type { InferProvable as InferSchema } from 'o1js';
+export { Schema } from './credentials/schema.ts';

--- a/src/o1js-missing.ts
+++ b/src/o1js-missing.ts
@@ -23,6 +23,7 @@ export {
   type ProvableHashableType,
   type ProvableHashablePure,
   type ProvableMaybeHashable,
+  type ProvableHashableWide,
   array,
   toFieldsPacked,
   hashPacked,
@@ -139,6 +140,13 @@ type ProvablePureType<T = any, V = any> = WithProvable<ProvablePure<T, V>>;
 type ProvableHashableType<T = any, V = any> = WithProvable<
   ProvableHashable<T, V>
 >;
+
+type ProvableHashableWide<T = any, V extends W = any, W = any> = Omit<
+  ProvableHashable<T, V>,
+  'fromValue'
+> & {
+  fromValue: (value: W) => T;
+};
 
 type ToProvable<A extends WithProvable<any>> = A extends {
   provable: infer P;

--- a/src/o1js-missing.ts
+++ b/src/o1js-missing.ts
@@ -141,11 +141,11 @@ type ProvableHashableType<T = any, V = any> = WithProvable<
   ProvableHashable<T, V>
 >;
 
-type ProvableHashableWide<T = any, V extends W = any, W = any> = Omit<
+type ProvableHashableWide<T = any, V = any, W = any> = Omit<
   ProvableHashable<T, V>,
   'fromValue'
 > & {
-  fromValue: (value: W) => T;
+  fromValue: (value: T | W) => T;
 };
 
 type ToProvable<A extends WithProvable<any>> = A extends {


### PR DESCRIPTION
Stacked behind #66
Closes #68

Adds a function `Schema()` that lets you define a schema using general data types like `Schema.String` without specifying maximum lengths.

Supported schema types currently are: String, Number, Boolean, Array, nested records and any provable types.

TODO: might be nice to add nullable types i.e. Schema.Option