### PR TITLE
Make hash operation dynamic

### DIFF
--- a/examples/unique-hash.eg.ts
+++ b/examples/unique-hash.eg.ts
@@ -9,9 +9,9 @@ import {
   assert,
   DynamicString,
   DynamicArray,
-  hashPacked,
   DynamicRecord,
   Schema,
+  hashDynamic,
 } from '../src/index.ts';
 import {
   issuer,
@@ -140,8 +140,7 @@ let request = PresentationRequest.https(
   spec,
   {
     acceptedNations: FieldArray.from(
-      // TODO we want hashDynamic here
-      acceptedNations.map((s) => hashPacked(String, String.from(s)))
+      acceptedNations.map((s) => hashDynamic(s))
     ),
     acceptedIssuers: FieldArray.from(acceptedIssuers),
     currentDate: UInt64.from(Date.now()),

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -6,6 +6,7 @@ import {
   hashDynamic,
   hashRecord,
   hashSafe,
+  hashSafeWithPrefix,
   hashString,
   packToField,
 } from './dynamic-hash.ts';
@@ -166,10 +167,14 @@ await test('collisions', async () => {
   });
 
   await test('No hashSafe collisions', () => {
-    hashSafe([]).assertNotEquals(hashSafe([Field(0)]));
-    hashSafe([]).assertNotEquals(hashSafe([Field(0), Field(0)]));
-    hashSafe([1, 2, 3].map(Field)).assertNotEquals(
-      hashSafe([1, 2, 3, 0].map(Field))
+    hashSafe([]).assertNotEquals(hashSafe([0]));
+    hashSafe([]).assertNotEquals(hashSafe([0, 0]));
+    hashSafe([1, 2, 3]).assertNotEquals(hashSafe([1, 2, 3, 0]));
+  });
+
+  await test('hashSafe with prefix', () => {
+    hashSafeWithPrefix('blub', [1, 2, 3]).assertNotEquals(
+      hashSafeWithPrefix('blob', [1, 2, 3])
     );
   });
 });

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -5,6 +5,7 @@ import {
   hashArray,
   hashDynamic,
   hashRecord,
+  hashSafe,
   hashString,
   packToField,
 } from './dynamic-hash.ts';
@@ -149,6 +150,26 @@ async function main() {
 
 await test('outside circuit', () => main());
 await test('inside circuit', () => Provable.runAndCheck(main));
+
+// hashSafe
+
+await test('collisions', async () => {
+  await test('Poseidon collisions', () => {
+    Poseidon.hash([]).assertEquals(Poseidon.hash([Field(0)]));
+    Poseidon.hash([]).assertEquals(Poseidon.hash([Field(0), Field(0)]));
+    Poseidon.hash([1, 2, 3].map(Field)).assertEquals(
+      Poseidon.hash([1, 2, 3, 0].map(Field))
+    );
+  });
+
+  await test('No hashSage collisions', () => {
+    hashSafe([]).assertNotEquals(hashSafe([Field(0)]));
+    hashSafe([]).assertNotEquals(hashSafe([Field(0), Field(0)]));
+    hashSafe([1, 2, 3].map(Field)).assertNotEquals(
+      hashSafe([1, 2, 3, 0].map(Field))
+    );
+  });
+});
 
 // comparison of constraint efficiency of different approaches
 

--- a/src/credentials/dynamic-hash.test.ts
+++ b/src/credentials/dynamic-hash.test.ts
@@ -111,13 +111,16 @@ async function main() {
     packToField(-1n).assertEquals(Field(-1n), 'pack bigint');
     packToField(true).assertEquals(Field(1), 'pack boolean');
     packToField(123).assertEquals(Field(123), 'pack number');
-    packToField(undefined).assertEquals(Poseidon.hash([]), 'pack undefined');
+    packToField(undefined).assertEquals(hashSafe([]), 'pack undefined');
 
     // hash is plain poseidon hash
-    hashDynamic(-1n).assertEquals(Poseidon.hash([Field(-1n)]), 'hash bigint');
-    hashDynamic(true).assertEquals(Poseidon.hash([Field(1)]), 'hash boolean');
-    hashDynamic(123).assertEquals(Poseidon.hash([Field(123)]), 'hash number');
-    hashDynamic(undefined).assertEquals(Poseidon.hash([]), 'pack undefined');
+    hashDynamic(-1n).assertEquals(hashSafe([Field(-1n)]), 'hash bigint');
+    hashDynamic(true).assertEquals(hashSafe([Field(1)]), 'hash boolean');
+    hashDynamic(123).assertEquals(hashSafe([Field(123)]), 'hash number');
+    hashDynamic(undefined).assertEquals(hashSafe([]), 'pack undefined');
+
+    // hash of several plain values is poseidon hash
+    hashDynamic(6n, 7, true).assertEquals(hashSafe([6, 7, 1].map(Field)));
   });
 
   // records of plain values
@@ -162,7 +165,7 @@ await test('collisions', async () => {
     );
   });
 
-  await test('No hashSage collisions', () => {
+  await test('No hashSafe collisions', () => {
     hashSafe([]).assertNotEquals(hashSafe([Field(0)]));
     hashSafe([]).assertNotEquals(hashSafe([Field(0), Field(0)]));
     hashSafe([1, 2, 3].map(Field)).assertNotEquals(

--- a/src/credentials/dynamic-hash.ts
+++ b/src/credentials/dynamic-hash.ts
@@ -28,6 +28,7 @@ import { BaseType } from './dynamic-base-types.ts';
 
 export {
   hashDynamic,
+  hashDynamicWithPrefix,
   hashArray,
   hashString,
   packToField,
@@ -73,6 +74,18 @@ function hashDynamic(...values: (HashableValue | unknown)[]) {
   }
   // for multiple inputs, first pack each of them and then hash
   return hashSafe(values.map((x) => packToField(x)));
+}
+
+function hashDynamicWithPrefix(
+  prefix: string | undefined,
+  ...values: (HashableValue | unknown)[]
+) {
+  if (prefix === undefined) return hashDynamic(...values);
+  // TODO it would be nice to avoid double hashing here,
+  // i.e. have it work exactly like `hashDynamic()` just with a prefix.
+  // but that would mean we have to thread the prefix through all our hashing algorithms
+  let fields = values.map((value) => packToField(value));
+  return hashSafeWithPrefix(prefix, fields);
 }
 
 /**

--- a/src/credentials/dynamic-hash.ts
+++ b/src/credentials/dynamic-hash.ts
@@ -12,7 +12,6 @@ import {
   Undefined,
 } from 'o1js';
 import {
-  hashPacked,
   type ProvableHashableType,
   ProvableType,
   toFieldsPacked,
@@ -38,6 +37,7 @@ export {
   provableTypeOf,
   innerArrayType,
   hashSafe,
+  hashSafeWithPrefix,
 };
 
 // compatible hashing
@@ -188,10 +188,23 @@ function hashString(string: string) {
  * These collisions are circumvented by using three different hash prefixes
  * for the 'even', 'odd' and 'zero' cases.
  */
-function hashSafe(fields: Field[]) {
+function hashSafe(fields: (Field | number | bigint)[]) {
   let n = fields.length;
-  let prefix = n === 0 ? 'zero' : n % 2 === 0 ? 'even' : 'odd';
-  return Poseidon.hashWithPrefix(prefix, fields);
+  let prefix = n === 0 ? 'zero' : n % 2 === 0 ? 'even' : 'odd_';
+  return Poseidon.hashWithPrefix(prefix, fields.map(Field));
+}
+
+function hashSafeWithPrefix(
+  prefix: string | undefined,
+  fields: (Field | number | bigint)[]
+) {
+  let n = fields.length;
+  let prefix2 = n === 0 ? 'zero' : n % 2 === 0 ? 'even' : 'odd_';
+  // TODO expose `prefixToFields()` to that we can implement this with two separate permutations
+  return Poseidon.hashWithPrefix(
+    `${prefix2}${prefix ?? ''}`,
+    fields.map(Field)
+  );
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,4 +8,5 @@ export { DynamicBytes } from './credentials/dynamic-bytes.ts';
 export { DynamicString } from './credentials/dynamic-string.ts';
 export { DynamicRecord } from './credentials/dynamic-record.ts';
 export { hashPacked } from './o1js-missing.ts';
+export { hashDynamic } from './credentials/dynamic-hash.ts';
 export { Schema } from './credentials/schema.ts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,5 +8,8 @@ export { DynamicBytes } from './credentials/dynamic-bytes.ts';
 export { DynamicString } from './credentials/dynamic-string.ts';
 export { DynamicRecord } from './credentials/dynamic-record.ts';
 export { hashPacked } from './o1js-missing.ts';
-export { hashDynamic } from './credentials/dynamic-hash.ts';
+export {
+  hashDynamic,
+  hashDynamicWithPrefix,
+} from './credentials/dynamic-hash.ts';
 export { Schema } from './credentials/schema.ts';

--- a/src/program-spec.ts
+++ b/src/program-spec.ts
@@ -6,14 +6,13 @@ import {
   Field,
   Provable,
   type ProvablePure,
-  Poseidon,
   Signature,
   PublicKey,
   type InferProvable,
 } from 'o1js';
 import type { ExcludeFromRecord } from './types.ts';
-import { assertPure, ProvableType, toFieldsPacked } from './o1js-missing.ts';
-import { assert, assertHasProperty, zip } from './util.ts';
+import { assertPure, ProvableType } from './o1js-missing.ts';
+import { assert, assertHasProperty } from './util.ts';
 import {
   type InferNestedProvable,
   NestedProvable,

--- a/src/program-spec.ts
+++ b/src/program-spec.ts
@@ -33,11 +33,7 @@ import {
   DynamicRecord,
   extractProperty,
 } from './credentials/dynamic-record.ts';
-import {
-  hashDynamic,
-  hashSafeWithPrefix,
-  packToField,
-} from './credentials/dynamic-hash.ts';
+import { hashDynamicWithPrefix } from './credentials/dynamic-hash.ts';
 
 export type {
   PublicInputs,
@@ -288,15 +284,7 @@ function evalNode<Data>(root: object, node: Node<Data>): Data {
     }
     case 'hash': {
       let inputs = node.inputs.map((i) => evalNode(root, i));
-
-      if (node.prefix === undefined) {
-        return hashDynamic(...inputs) as Data;
-      }
-      // TODO it would be nice to have `hashDynamic()` with a prefix as well, but
-      // that would mean we have to thread the prefix through all our hashing algorithms
-      let fields = inputs.map((value) => packToField(value));
-      let hash = hashSafeWithPrefix(node.prefix, fields);
-      return hash as Data;
+      return hashDynamicWithPrefix(node.prefix, ...inputs) as Data;
     }
     case 'ifThenElse': {
       let condition = evalNode(root, node.condition);

--- a/tests/program-spec.test.ts
+++ b/tests/program-spec.test.ts
@@ -15,6 +15,7 @@ import {
 import { issuerKey, owner } from './test-utils.ts';
 import { type CredentialOutputs } from '../src/credential.ts';
 import { Credential } from '../src/credential-index.ts';
+import { hashDynamic } from '../src/index.ts';
 
 function cred<D>(data: D): Credential<D> {
   return { owner, data };
@@ -224,7 +225,7 @@ test(' Spec and Node operations', async (t) => {
     );
 
     const inputValue = Field(123456);
-    const expectedHashValue = Poseidon.hash([inputValue]);
+    const expectedHashValue = hashDynamic(inputValue);
 
     const root: DataInputs<typeof spec.inputs> = {
       data: cred({ value: inputValue }),


### PR DESCRIPTION
Stacked behind #71

Change `Operations.hash()` to use dynamic hashing, so that it becomes more flexible and easier to use