### PR TITLE
refactor: createPresentation

### DIFF
--- a/src/presentation.ts
+++ b/src/presentation.ts
@@ -227,13 +227,13 @@ const Presentation = {
   /**
    * Prepare a presentation, given the request, context, and credentials
    *
-   * This way creating the presentation doesn't requre the private key of the owner but instead lets
-   * the wallet to handle the signing process
+   * This way creating the presentation doesn't require the private key of the owner but
+   * instead lets the wallet to handle the signing process
    */
   prepare: preparePresentation,
 
   /**
-   * Finalize presentation given request, signature and prepared data from preparePresentation
+   * Finalize presentation given request, signature, and prepared data from preparePresentation
    */
   finalize: finalizePresentation,
 

--- a/src/presentation.ts
+++ b/src/presentation.ts
@@ -335,7 +335,7 @@ async function preparePresentation<R extends PresentationRequest>({
   credentials: (StoredCredential & { key?: string })[];
 }): Promise<{
   context: Field;
-  fields: string[];
+  fieldsToSignStringArray: string[];
   credentialsUsed: Record<string, StoredCredential>;
   clientNonce: Field;
   compiledRequest: {
@@ -387,7 +387,7 @@ async function preparePresentation<R extends PresentationRequest>({
   const msg = fieldsToSign.toString();
   return {
     context,
-    fields: fieldsToSign.map((f) => f.toString()),
+    fieldsToSignStringArray: fieldsToSign.map((f) => f.toString()),
     credentialsUsed,
     clientNonce,
     compiledRequest: { program, verificationKey },
@@ -432,7 +432,7 @@ async function createPresentationPrepareFinalize<R extends PresentationRequest>(
   const prepared = await preparePresentation(params);
   const ownerSignature = Signature.create(
     ownerKey,
-    prepared.fields.map(Field.from)
+    prepared.fieldsToSignStringArray.map(Field.from)
   );
   return finalizePresentation(params.request, ownerSignature, prepared);
 }

--- a/src/presentation.ts
+++ b/src/presentation.ts
@@ -310,7 +310,7 @@ async function preparePresentation<R extends PresentationRequest>({
 
   // prepare fields to sign
   let credHashes = credentialsAndTypes.map(({ credentialType, credential }) =>
-    hashCredential(credentialType.data, credential)
+    hashCredential(credential)
   );
   let issuers = credentialsAndTypes.map(({ credentialType, witness }) =>
     credentialType.issuer(witness)

--- a/src/presentation.ts
+++ b/src/presentation.ts
@@ -225,6 +225,19 @@ const Presentation = {
   create: createPresentation,
 
   /**
+   * Prepare a presentation, given the request, context, and credentials
+   *
+   * This way creating the presentation doesn't requre the private key of the owner but instead lets
+   * the wallet to handle the signing process
+   */
+  prepare: preparePresentation,
+
+  /**
+   * Finalize presentation given request, signature and prepared data from preparePresentation
+   */
+  finalize: finalizePresentation,
+
+  /**
    * Verify a presentation against a request and context.
    *
    * Returns the verified output claim of the proof, to be consumed by application-specific logic.


### PR DESCRIPTION
This PR introduces `preparePresentation` and `finalizePresentation` which allow presentation creation without passing in the private key of the owner. Instead it returns the Fields that need to be signed and lets the wallet handle it.