### PR TITLE
Release `/dynamic` subpackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,67 @@
 
 This is where we implement Private Credentials: https://github.com/MinaFoundation/Core-Grants/issues/35#issuecomment-2318685738
 
+## `mina-credentials/dynamic`
+
+Under the import `mina-credentials/dynamic`, we export an entire library of dynamic data types and hashes with o1js.
+
+Features:
+
+- `DynamicSHA2` for hashing dynamic-length inputs with SHA2-256, -224, -384 or -512
+- `DynamicString` and `DynamicBytes` for representing strings and bytes
+- `DynamicArray`, a generalization of the above types to an arbitrary element type
+- `StaticArray`, which provides an API consistent with `DynamicArray` but for _fixed-length_ arrays (which aren't well-supported in o1js either)
+- `DynamicRecord`, a wrapper for objects that you don't necessarily know the exact layout of, but can be hashed and accessed properties of inside a circuit
+- `hashDynamic()`, for Poseidon-hashing pretty much any input (including plain strings, records, o1js types etc) in a way which is compatible to in-circuit hashing of padded data types like `DynamicRecord` and `DynamicArray`
+
+The library is intended to help with importing **real-world credentials** into the Mina ecosystem: For example, to "import" your passport, you have to verify the passport authority's signature on your passport data. The signature relies one of several hashing and signature schemes such as ECDSA, RSA and SHA2-256, SHA2-384, SHA2-512. Also, the signature will be over a dynamic-length string.
+
+Example of SHA-512-hashing a dynamic-length string:
+
+```ts
+import { Bytes, ZkProgram } from 'o1js';
+import { DynamicSHA2, DynamicString } from 'mina-credentials/dynamic';
+
+// allow strings up to length 100 as input
+const String = DynamicString({ maxLength: 100 });
+
+let sha512Program = ZkProgram({
+  name: 'sha512',
+  publicOutput: Bytes(64); // 64 bytes == 512 bits
+
+  methods: {
+    run: {
+      privateInputs: [String],
+      async method(string: DynamicString) {
+        let publicOutput = DynamicSHA2.hash(512, string);
+        return { publicOutput };
+      },
+    },
+  },
+});
+
+await sha512Program.compile();
+
+let result = await sha512Program.run(String.from('Hello, world!'));
+let provenHash: Bytes = result.proof.publicOutput;
+
+console.log(provenHash.toHex());
+```
+
 ## License
 
 [Apache-2.0](LICENSE)
+
+Copyright 2024 zkSecurity
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mina-credentials",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mina-credentials",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/chrome": "^0.0.272",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "exports": {
     ".": {
       "import": "./build/src/index.js"
+    },
+    "./dynamic": {
+      "import": "./build/src/dynamic.js"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mina-credentials",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Private Credentials on Mina",
   "author": "zksecurity <hello@zksecurity.xyz>",
   "license": "Apache-2.0",

--- a/src/dynamic.ts
+++ b/src/dynamic.ts
@@ -1,0 +1,11 @@
+export { DynamicArray } from './credentials/dynamic-array.ts';
+export { StaticArray } from './credentials/static-array.ts';
+export { DynamicBytes } from './credentials/dynamic-bytes.ts';
+export { DynamicString } from './credentials/dynamic-string.ts';
+export { DynamicRecord } from './credentials/dynamic-record.ts';
+export { DynamicSHA2 } from './credentials/dynamic-sha2.ts';
+export {
+  hashDynamic,
+  hashDynamicWithPrefix,
+} from './credentials/dynamic-hash.ts';
+export { Schema } from './credentials/schema.ts';

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -7,10 +7,10 @@ import {
 } from '../src/validation.ts';
 import { Bytes, Field, PublicKey, Signature } from 'o1js';
 import { owner, issuerKey } from './test-utils.ts';
-import { Spec, Claim, Operation, Constant } from '../src/program-spec.ts';
+import { Spec, Claim } from '../src/program-spec.ts';
 import { createProgram } from '../src/program.ts';
 import { createUnsigned } from '../src/credential.ts';
-import { PresentationRequest } from '../src/index.ts';
+import { Operation, PresentationRequest } from '../src/index.ts';
 
 const Bytes32 = Bytes(32);
 


### PR DESCRIPTION
Releases `mina-credential/dynamic` on a new minor version of our package

The separate package is to export a minimal amount of code to packages that don't directly use credentials (and credentials might even rely on some of those packages, like zkpassport, later on)

This is already released on npm as `mina-credentials@0.2.0`