### PR TITLE
Split SHA2 hash over multiple proofs

### DIFF
--- a/src/credentials/dynamic-array.test.ts
+++ b/src/credentials/dynamic-array.test.ts
@@ -1,5 +1,5 @@
 import { Provable } from 'o1js';
-import { DynamicString } from './dynamic-string.ts';
+import { DynamicString } from '../dynamic.ts';
 
 let String1 = DynamicString({ maxLength: 500 });
 let String2 = DynamicString({ maxLength: 100 });
@@ -8,7 +8,7 @@ let cs = await Provable.constraintSystem(() => {
   let s1 = Provable.witness(String1, () => 'blub');
   let s2 = Provable.witness(String2, () => 'blob');
 
-  s1.concat(s2);
+  let s12 = s1.concatByHashing(s2);
 });
 
 console.log(cs.summary());

--- a/src/credentials/dynamic-array.test.ts
+++ b/src/credentials/dynamic-array.test.ts
@@ -1,19 +1,38 @@
-import { Provable } from 'o1js';
-import { DynamicString } from '../dynamic.ts';
+import { Provable, UInt8 } from 'o1js';
+import { DynamicArray, DynamicString } from '../dynamic.ts';
 import { log } from './dynamic-hash.ts';
 
 let String1 = DynamicString({ maxLength: 100 });
 let String2 = DynamicString({ maxLength: 100 });
 
+let StringLike1 = DynamicArray(UInt8, { maxLength: String1.maxLength });
+let StringLike2 = DynamicArray(UInt8, { maxLength: String2.maxLength });
 let String12 = DynamicString({
   maxLength: String1.maxLength + String2.maxLength,
 });
 
 console.log(
-  'concat naive',
+  'baseline',
   await runAndConstraints(() => {
     let s1 = Provable.witness(String1, () => 'blub');
     let s2 = Provable.witness(String2, () => 'blob');
+  })
+);
+
+console.log(
+  'baseline + chunk',
+  await runAndConstraints(() => {
+    let s1 = Provable.witness(String1, () => 'blub');
+    let s2 = Provable.witness(String2, () => 'blob');
+    s1.chunk(8);
+  })
+);
+
+console.log(
+  'concat naive',
+  await runAndConstraints(() => {
+    let s1 = Provable.witness(StringLike1, () => String1.from('blub').array);
+    let s2 = Provable.witness(StringLike2, () => String2.from('blob').array);
 
     let s12 = s1.concat(s2);
     log(new String12(s12.array, s12.length));
@@ -39,6 +58,17 @@ console.log(
 
     let s12 = s1.concatByHashing(s2);
     log(new String12(s12.array, s12.length));
+  })
+);
+
+console.log(
+  'concat string',
+  await runAndConstraints(() => {
+    let s1 = Provable.witness(String1, () => 'blub');
+    let s2 = Provable.witness(String2, () => 'blob');
+
+    let s12 = s1.concat(s2);
+    log(s12);
   })
 );
 

--- a/src/credentials/dynamic-array.test.ts
+++ b/src/credentials/dynamic-array.test.ts
@@ -1,14 +1,48 @@
 import { Provable } from 'o1js';
 import { DynamicString } from '../dynamic.ts';
+import { log } from './dynamic-hash.ts';
 
-let String1 = DynamicString({ maxLength: 500 });
+let String1 = DynamicString({ maxLength: 100 });
 let String2 = DynamicString({ maxLength: 100 });
 
-let cs = await Provable.constraintSystem(() => {
-  let s1 = Provable.witness(String1, () => 'blub');
-  let s2 = Provable.witness(String2, () => 'blob');
-
-  let s12 = s1.concatByHashing(s2);
+let String12 = DynamicString({
+  maxLength: String1.maxLength + String2.maxLength,
 });
 
-console.log(cs.summary());
+console.log(
+  'concat naive',
+  await runAndConstraints(() => {
+    let s1 = Provable.witness(String1, () => 'blub');
+    let s2 = Provable.witness(String2, () => 'blob');
+
+    let s12 = s1.concat(s2);
+    log(new String12(s12.array, s12.length));
+  })
+);
+
+console.log(
+  'concat transposed',
+  await runAndConstraints(() => {
+    let s1 = Provable.witness(String1, () => 'blub');
+    let s2 = Provable.witness(String2, () => 'blob');
+
+    let s12 = s1.concatTransposed(s2);
+    log(new String12(s12.array, s12.length));
+  })
+);
+
+console.log(
+  'concat with hashing',
+  await runAndConstraints(() => {
+    let s1 = Provable.witness(String1, () => 'blub');
+    let s2 = Provable.witness(String2, () => 'blob');
+
+    let s12 = s1.concatByHashing(s2);
+    log(new String12(s12.array, s12.length));
+  })
+);
+
+async function runAndConstraints(fn: () => Promise<void> | void) {
+  await Provable.runAndCheck(fn);
+  return (await Provable.constraintSystem(fn)).summary();
+}

--- a/src/credentials/dynamic-array.test.ts
+++ b/src/credentials/dynamic-array.test.ts
@@ -1,0 +1,14 @@
+import { Provable } from 'o1js';
+import { DynamicString } from './dynamic-string.ts';
+
+let String1 = DynamicString({ maxLength: 500 });
+let String2 = DynamicString({ maxLength: 100 });
+
+let cs = await Provable.constraintSystem(() => {
+  let s1 = Provable.witness(String1, () => 'blub');
+  let s2 = Provable.witness(String2, () => 'blob');
+
+  s1.concat(s2);
+});
+
+console.log(cs.summary());

--- a/src/credentials/dynamic-hash.ts
+++ b/src/credentials/dynamic-hash.ts
@@ -6,6 +6,7 @@ import {
   Bytes,
   Field,
   Poseidon,
+  Provable,
   Struct,
   UInt64,
   UInt8,
@@ -21,6 +22,7 @@ import {
   hasProperty,
   isSubclass,
   mapEntries,
+  mapObject,
   stringLength,
 } from '../util.ts';
 import type { UnknownRecord } from './dynamic-record.ts';
@@ -39,6 +41,8 @@ export {
   innerArrayType,
   hashSafe,
   hashSafeWithPrefix,
+  toValue,
+  log,
 };
 
 // compatible hashing
@@ -329,6 +333,30 @@ function provableTypeEquals(
 }
 
 // helpers
+
+function toValue(value: unknown): any {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') return value;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'bigint') return value;
+  if (value === undefined || value === null) return value;
+  if (Array.isArray(value)) value.map(toValue);
+
+  let type = provableTypeOfConstructor(value);
+
+  // unknown object
+  if (type === undefined) return mapObject(value, toValue);
+
+  // other types use directly
+  return ProvableType.get(type).toValue(value);
+}
+
+function log(...values: any[]) {
+  Provable.asProver(() => {
+    let mapped = values.map(toValue);
+    console.log(...mapped);
+  });
+}
 
 function isStruct(type: ProvableType): type is Struct<any> {
   return (

--- a/src/credentials/dynamic-sha2-update.test.ts
+++ b/src/credentials/dynamic-sha2-update.test.ts
@@ -18,8 +18,8 @@ const Bytes32 = Bytes(32);
 const BLOCKS_PER_ITERATION = 7;
 
 class State extends Sha2IterationState(256) {}
-const Iteration = Sha2Iteration(256, BLOCKS_PER_ITERATION);
-const FinalIteration = Sha2FinalIteration(256, BLOCKS_PER_ITERATION);
+class Iteration extends Sha2Iteration(256, BLOCKS_PER_ITERATION) {}
+class FinalIteration extends Sha2FinalIteration(256, BLOCKS_PER_ITERATION) {}
 
 let sha2Update = ZkProgram({
   name: 'sha2-update',
@@ -28,8 +28,8 @@ let sha2Update = ZkProgram({
   methods: {
     initial: {
       privateInputs: [Iteration],
-      async method(iteration: Sha2Iteration) {
-        let state = Sha2IterationState.initial(256);
+      async method(iteration: Iteration) {
+        let state = State.initial();
         let publicOutput = DynamicSHA2.update(state, iteration);
         return { publicOutput };
       },
@@ -37,10 +37,7 @@ let sha2Update = ZkProgram({
 
     recursive: {
       privateInputs: [SelfProof, Iteration],
-      async method(
-        proof: SelfProof<undefined, State>,
-        iteration: Sha2Iteration
-      ) {
+      async method(proof: SelfProof<undefined, State>, iteration: Iteration) {
         proof.verify();
         let state = proof.publicOutput;
         let publicOutput = DynamicSHA2.update(state, iteration);
@@ -62,7 +59,7 @@ let sha2Finalize = ZkProgram({
       async method(
         string: DynamicString,
         proof: UpdateProof,
-        iteration: Sha2FinalIteration
+        iteration: FinalIteration
       ) {
         proof.verify();
         let state = proof.publicOutput;

--- a/src/credentials/dynamic-sha2-update.test.ts
+++ b/src/credentials/dynamic-sha2-update.test.ts
@@ -1,0 +1,116 @@
+/**
+ * This example computes the SHA2 hash of a long string in multiple chunks, using recursion
+ * and the `DynamicSHA2` `split()` / `update()` / `finalize()` API.
+ */
+import { Bytes, SelfProof, ZkProgram } from 'o1js';
+import {
+  DynamicSHA2,
+  DynamicString,
+  Sha2IterationState,
+  Sha2Iteration,
+  Sha2FinalIteration,
+} from '../dynamic.ts';
+import { mapObject } from '../util.ts';
+
+const String = DynamicString({ maxLength: 850 });
+const Bytes32 = Bytes(32);
+
+const BLOCKS_PER_ITERATION = 7;
+
+class State extends Sha2IterationState(256) {}
+const Iteration = Sha2Iteration(256, BLOCKS_PER_ITERATION);
+const FinalIteration = Sha2FinalIteration(256, BLOCKS_PER_ITERATION);
+
+let sha2Update = ZkProgram({
+  name: 'sha2-update',
+  publicOutput: State,
+
+  methods: {
+    initial: {
+      privateInputs: [Iteration],
+      async method(iteration: Sha2Iteration) {
+        let state = Sha2IterationState.initial(256);
+        let publicOutput = DynamicSHA2.update(state, iteration);
+        return { publicOutput };
+      },
+    },
+
+    recursive: {
+      privateInputs: [SelfProof, Iteration],
+      async method(
+        proof: SelfProof<undefined, State>,
+        iteration: Sha2Iteration
+      ) {
+        proof.verify();
+        let state = proof.publicOutput;
+        let publicOutput = DynamicSHA2.update(state, iteration);
+        return { publicOutput };
+      },
+    },
+  },
+});
+
+class UpdateProof extends ZkProgram.Proof(sha2Update) {}
+
+let sha2Finalize = ZkProgram({
+  name: 'sha2-finalize',
+  publicOutput: Bytes32,
+
+  methods: {
+    run: {
+      privateInputs: [String, UpdateProof, FinalIteration],
+      async method(
+        string: DynamicString,
+        proof: UpdateProof,
+        iteration: Sha2FinalIteration
+      ) {
+        proof.verify();
+        let state = proof.publicOutput;
+        let publicOutput = DynamicSHA2.finalize(state, iteration, string);
+        return { publicOutput };
+      },
+    },
+  },
+});
+
+console.log(mapObject(await sha2Update.analyzeMethods(), (m) => m.summary()));
+console.log(mapObject(await sha2Finalize.analyzeMethods(), (m) => m.summary()));
+
+// split up string into chunks to be hashed
+
+let longString = String.from('hello world!'.repeat(Math.floor(850 / 12)));
+console.log('string length', longString.toString().length);
+
+let { iterations, final } = DynamicSHA2.split(
+  256,
+  BLOCKS_PER_ITERATION,
+  longString
+);
+
+console.log('number of iterations (including final):', iterations.length + 1);
+
+console.time('compile');
+await sha2Update.compile();
+await sha2Finalize.compile();
+console.timeEnd('compile');
+
+let [first, ...rest] = iterations;
+
+console.time('proof (initial)');
+let { proof } = await sha2Update.initial(first!);
+console.timeEnd('proof (initial)');
+
+console.time(`proof (recursive ${rest.length}x)`);
+for (let iteration of rest) {
+  ({ proof } = await sha2Update.recursive(proof, iteration));
+}
+console.timeEnd(`proof (recursive ${rest.length}x)`);
+
+console.time('proof (finalize)');
+let { proof: finalProof } = await sha2Finalize.run(longString, proof, final);
+console.timeEnd('proof (finalize)');
+
+console.log('public output:\n', finalProof.publicOutput.toHex());
+
+// compare with expected hash
+console.log('expected hash:\n', DynamicSHA2.hash(256, longString).toHex());

--- a/src/credentials/dynamic-sha2-update.test.ts
+++ b/src/credentials/dynamic-sha2-update.test.ts
@@ -15,6 +15,9 @@ import { mapObject } from '../util.ts';
 const String = DynamicString({ maxLength: 850 });
 const Bytes32 = Bytes(32);
 
+/**
+ * How many SHA2 blocks to process in each proof.
+ */
 const BLOCKS_PER_ITERATION = 7;
 
 class State extends Sha2IterationState(256) {}

--- a/src/credentials/dynamic-sha2.ts
+++ b/src/credentials/dynamic-sha2.ts
@@ -1,11 +1,22 @@
-import { Bytes, Provable, UInt32, UInt64, UInt8 } from 'o1js';
+import {
+  Bytes,
+  Field,
+  Provable,
+  type ProvablePure,
+  Struct,
+  UInt32,
+  UInt64,
+  UInt8,
+} from 'o1js';
 import { DynamicArray } from './dynamic-array.ts';
 import { StaticArray } from './static-array.ts';
-import { chunk, pad } from '../util.ts';
+import { assert, chunk, pad } from '../util.ts';
 import { SHA2 } from './sha2.ts';
 import { uint64FromBytesBE, uint64ToBytesBE } from './gadgets.ts';
+import { hashSafe } from './dynamic-hash.ts';
+import { ProvableType, toFieldsPacked } from '../o1js-missing.ts';
 
-export { DynamicSHA2 };
+export { DynamicSHA2, Sha2IterationState, Sha2Iteration, Sha2FinalIteration };
 
 const DynamicSHA2 = {
   /**
@@ -29,6 +40,10 @@ const DynamicSHA2 = {
    */
   hash: sha2,
 
+  split,
+  update,
+  finalize,
+
   padding256,
   padding512,
 };
@@ -39,13 +54,15 @@ function sha2(len: 224 | 256 | 384 | 512, bytes: DynamicArray<UInt8>): Bytes {
   throw new Error('unsupported hash length');
 }
 
+type Length = 224 | 256 | 384 | 512;
+
 // static array types for blocks / state / result
 class UInt8x4 extends StaticArray(UInt8, 4) {}
 class UInt8x8 extends StaticArray(UInt8, 8) {}
 class UInt8x64 extends StaticArray(UInt8, 64) {}
 class UInt8x128 extends StaticArray(UInt8, 128) {}
-class Block extends StaticArray(UInt32, 16) {}
-class State extends StaticArray(UInt32, 8) {}
+class Block32 extends StaticArray(UInt32, 16) {}
+class State32 extends StaticArray(UInt32, 8) {}
 class Block64 extends StaticArray(UInt64, 16) {}
 class State64 extends StaticArray(UInt64, 8) {}
 const Bytes28 = Bytes(28);
@@ -58,11 +75,11 @@ function hash256(len: 224 | 256, bytes: DynamicArray<UInt8>): Bytes {
 
   // hash a dynamic number of blocks using DynamicArray.reduce()
   let state = blocks.reduce(
-    State,
-    State.from(SHA2.initialState256(len)),
+    State32,
+    State32.from(SHA2.initialState256(len)),
     (state, block) => {
       let W = SHA2.messageSchedule256(block.array);
-      return State.from(SHA2.compression256(state.array, W));
+      return State32.from(SHA2.compression256(state.array, W));
     }
   );
 
@@ -94,7 +111,7 @@ function hash512(len: 384 | 512, bytes: DynamicArray<UInt8>): Bytes {
  */
 function padding256(
   message: DynamicArray<UInt8>
-): DynamicArray<StaticArray<UInt32>> {
+): DynamicArray<StaticArray<UInt32>, bigint[]> {
   /* padded message looks like this:
   
   M ... M 0x80 0x0 ... 0x0 L L L L L L L L
@@ -132,7 +149,7 @@ function padding256(
   let blocksOfBytes = new BlocksOfBytes(chunked, numberOfBlocks);
 
   // pack each block of 64 bytes into 16 uint32s (4 bytes each)
-  let blocks = blocksOfBytes.map(Block, (block) =>
+  let blocks = blocksOfBytes.map(Block32, (block) =>
     block.chunk(4).map(UInt32, (b) => UInt32.fromBytesBE(b.array))
   );
 
@@ -207,7 +224,7 @@ function padding512(
   let chunked = chunk(padded, 128).map(UInt8x128.from);
   let blocksOfBytes = new BlocksOfBytes(chunked, numberOfBlocks);
 
-  // pack each block of 64 bytes into 16 uint64s (8 bytes each)
+  // pack each block of 128 bytes into 16 uint64s (8 bytes each)
   let blocks = blocksOfBytes.map(Block64, (block) =>
     block.chunk(8).map(UInt64, (b) => uint64FromBytesBE(b.array))
   );
@@ -239,4 +256,200 @@ function splitMultiIndex64(index: UInt32) {
   let { rest: l0, quotient: l1 } = index.divMod(128);
   let { rest: l00, quotient: l01 } = l0.divMod(8);
   return [l00.value, l01.value, l1.value] as const;
+}
+
+// updating API
+
+type Sha2IterationState<L extends Length = Length> = L extends 224 | 256
+  ? { len: L; state: State32; commitment: Field }
+  : { len: L; state: State64; commitment: Field };
+
+type Sha2Iteration =
+  | { type: 256; blocks: StaticArray<Block32> }
+  | { type: 512; blocks: StaticArray<Block64> };
+
+type Sha2FinalIteration =
+  | { type: 256; blocks: DynamicArray<Block32> }
+  | { type: 512; blocks: DynamicArray<Block64> };
+
+function initialState<L extends Length>(len: L): Sha2IterationState<L>;
+function initialState(len: Length): Sha2IterationState {
+  if (len === 224 || len === 256) {
+    return {
+      len,
+      state: State32.from(SHA2.initialState256(len)),
+      commitment: Field(0),
+    };
+  } else {
+    return {
+      len,
+      state: State64.from(SHA2.initialState512(len)),
+      commitment: Field(0),
+    };
+  }
+}
+
+function split<L extends Length>(
+  len: L,
+  blocksPerIteration: number,
+  bytes: DynamicArray<UInt8>
+): {
+  initial: Sha2IterationState<L>;
+  iterations: Sha2Iteration[];
+  final: Sha2FinalIteration;
+} {
+  let initial = initialState(len);
+
+  if (len === 224 || len === 256) {
+    let blocks = padding256(bytes);
+    let [iterations, final] = blocks.chunk(blocksPerIteration);
+    return {
+      initial,
+      iterations: iterations.array
+        .slice(0, Number(iterations.length))
+        .map((blocks) => ({ type: 256, blocks })),
+      final: { type: 256, blocks: final },
+    };
+  } else {
+    let blocks = padding512(bytes);
+    let [iterations, final] = blocks.chunk(blocksPerIteration);
+    return {
+      initial,
+      iterations: iterations.array
+        .slice(0, Number(iterations.length))
+        .map((blocks) => ({ type: 512, blocks })),
+      final: { type: 512, blocks: final },
+    };
+  }
+}
+
+function update<L extends Length>(
+  iterState: Sha2IterationState<L>,
+  iteration: Sha2Iteration
+): Sha2IterationState<L>;
+
+function update(
+  iterState: Sha2IterationState,
+  iteration: Sha2Iteration
+): Sha2IterationState {
+  if (iterState.len === 224 || iterState.len === 256) {
+    assert(iteration.type === 256, 'incompatible types');
+
+    // update hash state and commitment
+    let { state, commitment } = iterState;
+    state = iteration.blocks.reduce(state, processBlock256);
+    commitment = iteration.blocks.reduce(commitment, commitBlock256);
+
+    return { len: iterState.len, state, commitment };
+  } else {
+    assert(iterState.len === 384 || iterState.len === 512, 'invalid state');
+    assert(iteration.type === 512, 'incompatible types');
+
+    // update hash state and commitment
+    let { state, commitment } = iterState;
+    state = iteration.blocks.reduce(state, processBlock512);
+    commitment = iteration.blocks.reduce(commitment, commitBlock512);
+
+    return { len: iterState.len, state, commitment };
+  }
+}
+
+function finalize(
+  iterState: Sha2IterationState,
+  final: Sha2FinalIteration,
+  bytes: DynamicArray<UInt8>
+): Bytes {
+  if (iterState.len === 224 || iterState.len === 256) {
+    assert(final.type === 256, 'incompatible types');
+
+    // update hash state and commitment
+    let { state, commitment } = iterState;
+    state = final.blocks.reduce(State32, state, processBlock256);
+    commitment = final.blocks.reduce(Field, commitment, commitBlock256);
+
+    // recompute commitment from scratch to confirm we really hashed the input bytes
+    let expected = padding256(bytes).reduce(Field, Field(0), commitBlock256);
+    commitment.assertEquals(expected, 'invalid commitment');
+
+    // finalize hash
+    let result = state.array.flatMap((x) => x.toBytesBE());
+    return iterState.len === 224 ? Bytes28.from(result) : Bytes32.from(result);
+  } else {
+    assert(iterState.len === 384 || iterState.len === 512, 'invalid state');
+    assert(final.type === 512, 'incompatible types');
+
+    // update hash state and commitment
+    let { state, commitment } = iterState;
+    state = final.blocks.reduce(State64, state, processBlock512);
+    commitment = final.blocks.reduce(Field, commitment, commitBlock512);
+
+    // recompute commitment from scratch to confirm we really hashed the input bytes
+    let expected = padding512(bytes).reduce(Field, Field(0), commitBlock512);
+    commitment.assertEquals(expected, 'invalid commitment');
+
+    // finalize hash
+    let result = state.array.flatMap((x) => uint64ToBytesBE(x));
+    return iterState.len === 384 ? Bytes48.from(result) : Bytes64.from(result);
+  }
+}
+
+// provable types for update API
+
+function Sha2IterationState<L extends Length>(
+  len: L
+): Struct<Sha2IterationState<L>> & ProvablePure<Sha2IterationState<L>> {
+  return Struct({
+    len: ProvableType.constant(len),
+    state: State(len),
+    commitment: Field,
+  });
+}
+Sha2IterationState.initial = initialState;
+
+function Sha2Iteration(
+  len: Length,
+  blocksPerIteration: number
+): Struct<Sha2Iteration> {
+  return Struct({
+    type: ProvableType.constant(len === 224 || len === 256 ? 256 : 512),
+    blocks: StaticArray(Block(len), blocksPerIteration),
+  });
+}
+
+function Sha2FinalIteration(
+  len: Length,
+  blocksPerIteration: number
+): Struct<Sha2FinalIteration> {
+  return Struct({
+    type: ProvableType.constant(len),
+    blocks: DynamicArray(Block(len), { maxLength: blocksPerIteration }),
+  });
+}
+
+// helpers for update API
+
+function processBlock256(state: State32, block: Block32): State32 {
+  let W = SHA2.messageSchedule256(block.array);
+  return State32.from(SHA2.compression256(state.array, W));
+}
+function processBlock512(state: State64, block: Block64): State64 {
+  let W = SHA2.messageSchedule512(block.array);
+  return State64.from(SHA2.compression512(state.array, W));
+}
+
+// poseidon hash for keeping a commitment to the blocks that were hashed
+function commitBlock256(commitment: Field, block: Block32): Field {
+  let blockHash = hashSafe(toFieldsPacked(Block32, block));
+  return hashSafe([commitment, blockHash]);
+}
+function commitBlock512(commitment: Field, block: Block64): Field {
+  let blockHash = hashSafe(toFieldsPacked(Block64, block));
+  return hashSafe([commitment, blockHash]);
+}
+
+function Block(len: 224 | 256 | 384 | 512) {
+  return len === 224 || len === 256 ? Block32 : Block64;
+}
+function State(len: 224 | 256 | 384 | 512) {
+  return len === 224 || len === 256 ? State32 : State64;
 }

--- a/src/credentials/static-array.ts
+++ b/src/credentials/static-array.ts
@@ -8,6 +8,7 @@ import {
   type InferValue,
   Gadgets,
   type ProvableHashable,
+  type From,
 } from 'o1js';
 import { assert, assertHasProperty, chunk, zip } from '../util.ts';
 import { ProvableType } from '../o1js-missing.ts';
@@ -40,7 +41,7 @@ function StaticArray<
   /**
    * Create a new StaticArray from a raw array of values.
    */
-  from(v: (T | V)[] | StaticArrayBase<T, V>): StaticArrayBase<T, V>;
+  from(v: (T | From<A>)[] | StaticArrayBase<T, V>): StaticArrayBase<T, V>;
 } {
   let innerType: Provable<T, V> = ProvableType.get(type);
 
@@ -96,6 +97,12 @@ class StaticArrayBase<T = any, V = any> {
   // derived prop
   get length(): number {
     return (this.constructor as typeof StaticArrayBase).length;
+  }
+  /**
+   * The `length` of the array. For compatibility with `DynamicArray`, we also provide is under `maxLength`.
+   */
+  get maxLength() {
+    return this.length;
   }
 
   constructor(array: T[]) {

--- a/src/dynamic.ts
+++ b/src/dynamic.ts
@@ -3,7 +3,12 @@ export { StaticArray } from './credentials/static-array.ts';
 export { DynamicBytes } from './credentials/dynamic-bytes.ts';
 export { DynamicString } from './credentials/dynamic-string.ts';
 export { DynamicRecord } from './credentials/dynamic-record.ts';
-export { DynamicSHA2 } from './credentials/dynamic-sha2.ts';
+export {
+  DynamicSHA2,
+  Sha2IterationState,
+  Sha2Iteration,
+  Sha2FinalIteration,
+} from './credentials/dynamic-sha2.ts';
 export {
   hashDynamic,
   hashDynamicWithPrefix,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,5 +13,7 @@ export { hashPacked } from './o1js-missing.ts';
 export {
   hashDynamic,
   hashDynamicWithPrefix,
+  log,
+  toValue,
 } from './credentials/dynamic-hash.ts';
 export { Schema } from './credentials/schema.ts';


### PR DESCRIPTION
- **very naive first go at concat circuit**
- **hashing can be more efficient**
- **dynamic chunk method**
- **another variant of concat**
- **very efficient string concat**
- **infer purity for static array**
- **update mode for dynamic sha2**
- **test which splits long sha2 hash across proofs**
- **more generics for better API**
- **docs for new API**
